### PR TITLE
feat(devcontainer): install nx globally

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 yarn install
 
 # Install Nx globally so commands can run without yarn
-npm install -g nx
+yarn global add nx
 
 yarn lint --fix
 

--- a/README.md
+++ b/README.md
@@ -5,5 +5,5 @@
 2. Wait for dependencies to install with Yarn.
 3. Ports `3000` and `6006` are forwarded.
 4. Formatting, linting, and type checks run automatically after creation.
-5. The Nx CLI is installed globally so you can run `nx` directly.
+5. The Nx CLI is installed globally with Yarn so you can run `nx` directly.
 


### PR DESCRIPTION
## Why
Provide the Nx CLI globally in the dev container so developers can invoke `nx` directly without using `yarn`.

## Notes
- README updated to document availability of the global Nx CLI.


------
https://chatgpt.com/codex/tasks/task_e_684bd79cbba883269914ceb9d8b55c98

## Summary by Sourcery

Install the Nx CLI globally in the dev container for direct usage and update documentation accordingly.

New Features:
- Install Nx CLI globally in the dev container to allow running `nx` without using `yarn`.

Documentation:
- Update README to note that the Nx CLI is available globally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated development environment to install the Nx CLI globally, allowing direct use of the nx command.
- **Documentation**
  - Updated setup instructions to reflect the global installation of the Nx CLI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->