### PR TITLE
feat(devcontainer): upgrade to node 22

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Electric MDD UK Dev Container",
-  "image": "mcr.microsoft.com/vscode/devcontainers/typescript-node:0-20-bullseye",
+  "image": "mcr.microsoft.com/vscode/devcontainers/typescript-node:0-22-bullseye",
   "postCreateCommand": "bash .devcontainer/post-create.sh",
   "forwardPorts": [3000, 6006]
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "scripts": {
     "nx": "nx"
   },
+  "engines": {
+    "node": ">=22"
+  },
   "devDependencies": {
     "nx": "^21.2.0"
   }


### PR DESCRIPTION
## Summary
- switch devcontainer image to Node 22

## Why
- align development environment with latest Node LTS

------
https://chatgpt.com/codex/tasks/task_e_684c123ae8408326a861598518b1c099

## Summary by Sourcery

Enhancements:
- Switch devcontainer base image to Node.js 22 to align development environment with latest LTS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Docker image version used in the development container for improved environment consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->