### PR TITLE
feat(docs): add project goals and contribution section

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+# Pull Request
+**Title format:** `feat(scope): summary`
+
+## Why
+Explain the value of this change.
+
+## Checklist
+- [ ] Lint and format (`yarn lint --fix` && `yarn format`)
+- [ ] Type check (`yarn ts:check`)
+- [ ] Unit tests (`yarn nx run-many --target=test`)
+- [ ] Label this PR with `release:patch|minor|major`
+
+## Notes
+Any extra information.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,14 @@
 A self-service web and API tool that ensures ≥ 99.5% of new-connection quotes use
 valid top-line combinations, slashing average quote time and saving on
 rejection fees and rework, while meeting engineering, compliance and
-observability standards. The project exposes the underlying medical device
-dataset through a Next.js and Nx stack, sourced read-only via Prisma to keep
-records consistent.
+observability standards. The project exposes the underlying Market Domain Data
+through a Next.js and Nx stack, sourced read-only via Prisma to keep records
+consistent.
+
+## Contributing
+
+Run `yarn lint --fix`, `yarn format` and `yarn ts:check` before committing.
+Execute `yarn nx run-many --target=test` and `yarn test` to verify behaviour.
+Use the PR title pattern `feat(scope): summary` and label your PR with
+`release:patch`, `release:minor` or `release:major`.
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,30 @@
 # Electric MDD UK
 
 ## Development Container
+
 1. Open the repository in VS Code, and select **Reopen in Container**.
 2. Wait for dependencies to install with Yarn.
 3. Ports `3000` and `6006` are forwarded.
 4. Formatting, linting, and type checks run automatically after creation.
 5. The Nx CLI is installed globally with Yarn so you can run `nx` directly.
 
+## Project Goals
+
+The aim of this project is to build a reliable, open-source medical device
+database for the UK. We use a Next.js and Nx stack to host and visualise the
+data. All device information is retrieved through the read-only Prisma client
+so the dataset stays consistent.
+
+## Contributing
+
+We welcome improvements and bug fixes. Before opening a pull request:
+
+1. Format and lint the code with `yarn lint --fix` and `yarn format`.
+2. Check types via `yarn ts:check` and run tests with `yarn test`.
+3. Use 2-space indentation and prefer single quotes in TypeScript files.
+4. Commit messages should be imperative, and PR titles follow the
+   `feat(scope): summary` convention.
+5. Label the PR with `release:patch`, `release:minor`, or `release:major` to
+   trigger semantic-release.
+
+For questions or new ideas, please open an issue first.

--- a/README.md
+++ b/README.md
@@ -10,10 +10,12 @@
 
 ## Project Goals
 
-The aim of this project is to build a reliable, open-source medical device
-database for the UK. We use a Next.js and Nx stack to host and visualise the
-data. All device information is retrieved through the read-only Prisma client
-so the dataset stays consistent.
+A self-service web and API tool that ensures ≥ 99.5% of new-connection quotes use
+valid top-line combinations, slashing average quote time and saving on
+rejection fees and rework, while meeting engineering, compliance and
+observability standards. The project exposes the underlying medical device
+dataset through a Next.js and Nx stack, sourced read-only via Prisma to keep
+records consistent.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -17,16 +17,3 @@ observability standards. The project exposes the underlying medical device
 dataset through a Next.js and Nx stack, sourced read-only via Prisma to keep
 records consistent.
 
-## Contributing
-
-We welcome improvements and bug fixes. Before opening a pull request:
-
-1. Format and lint the code with `yarn lint --fix` and `yarn format`.
-2. Check types via `yarn ts:check` and run tests with `yarn test`.
-3. Use 2-space indentation and prefer single quotes in TypeScript files.
-4. Commit messages should be imperative, and PR titles follow the
-   `feat(scope): summary` convention.
-5. Label the PR with `release:patch`, `release:minor`, or `release:major` to
-   trigger semantic-release.
-
-For questions or new ideas, please open an issue first.


### PR DESCRIPTION
## Why
Clarifies repository purpose and how to contribute.

Label: `release:patch`

------
https://chatgpt.com/codex/tasks/task_e_684c1b0346848326a131ba06957394fc

## Summary by Sourcery

Add project goals and contributing sections to the README to clarify the repository's purpose and contribution process.

Documentation:
- Add "Project Goals" section outlining the project's objectives and tech stack.
- Add "Contributing" section detailing code formatting, testing, and PR labeling guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded the README with a new "Project Goals" section outlining the project's objectives and architecture.
  - Added a pull request template to standardise submission format and ensure completeness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->