### PR TITLE
feat(devcontainer): update base image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Electric MDD UK Dev Container",
-  "image": "mcr.microsoft.com/vscode/devcontainers/typescript-node:0-22-bullseye",
+  "image": "mcr.microsoft.com/vscode/devcontainers/typescript-node:20-bullseye",
   "postCreateCommand": "bash .devcontainer/post-create.sh",
   "forwardPorts": [3000, 6006]
 }


### PR DESCRIPTION
## Why
Use a standard public image so the dev container works without private registry access.

## Summary
- update devcontainer base image to `mcr.microsoft.com/vscode/devcontainers/typescript-node:20-bullseye`

## Testing
- `yarn lint --fix` *(fails: Couldn't find a script named "lint")*
- `yarn format` *(fails: Couldn't find a script named "format")*
- `yarn ts:check` *(fails: Couldn't find a script named "ts:check")*
- `yarn test` *(fails: Couldn't find a script named "test")*
- `devcontainer up --workspace-folder .` *(fails: spawn docker ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_684c275e73108326bdd9f92832b7f3de

## Summary by Sourcery

Enhancements:
- Switch devcontainer base image to mcr.microsoft.com/vscode/devcontainers/typescript-node:20-bullseye