### PR TITLE
feat(devcontainer): use public node image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Electric MDD UK Dev Container",
-  "image": "mcr.microsoft.com/vscode/devcontainers/typescript-node:0-22-bullseye",
+  "image": "node:22-bullseye",
   "postCreateCommand": "bash .devcontainer/post-create.sh",
   "forwardPorts": [3000, 6006]
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Electric MDD UK Dev Container",
-  "image": "node:22-bullseye",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:22-bullseye",
   "postCreateCommand": "bash .devcontainer/post-create.sh",
   "forwardPorts": [3000, 6006]
 }


### PR DESCRIPTION
## Why
Use `node:22-bullseye` so contributors can build the devcontainer without relying on Microsoft-registry images.

## Testing
- `yarn lint --fix` *(fails: Couldn't find a script named "lint")*
- `yarn format` *(fails: Couldn't find a script named "format")*
- `yarn ts:check` *(fails: Couldn't find a script named "ts:check")*
- `yarn nx run-many --target=test` *(no tasks were run)*
- `yarn e2e` *(fails: Couldn't find a script named "e2e")*
- `devcontainer up --workspace-folder .` *(fails: spawn docker ENOENT)*

Label: `release:patch`


------
https://chatgpt.com/codex/tasks/task_e_684c28f4233c8326882d28a45d37324f

## Summary by Sourcery

Enhancements:
- Switch devcontainer base image to node:22-bullseye and remove reliance on Microsoft registry images

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the development container to use a more general Node.js base image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->