### PR TITLE
feat(db): add initial prisma schema

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,3 +13,97 @@ datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
 }
+
+enum MarketParticipantRoleCode {
+  ROLE0 @map("0")
+  ROLE1 @map("1")
+  ROLE2 @map("2")
+  ROLE3 @map("3")
+  ROLE4 @map("4")
+  ROLE5 @map("5")
+  ROLE6 @map("6")
+  ROLE7 @map("7")
+  ROLE8 @map("8")
+  ROLE9 @map("9")
+  ROLEA @map("A")
+  ROLEB @map("B")
+  ROLEC @map("C")
+  ROLED @map("D")
+  ROLEE @map("E")
+  ROLEF @map("F")
+  ROLEG @map("G")
+  ROLEH @map("H")
+  ROLEI @map("I")
+  ROLEJ @map("J")
+  ROLEK @map("K")
+  ROLEL @map("L")
+  ROLEM @map("M")
+  ROLEN @map("N")
+  ROLEO @map("O")
+  ROLEP @map("P")
+  ROLEQ @map("Q")
+  ROLER @map("R")
+  ROLES @map("S")
+  ROLET @map("T")
+  ROLEU @map("U")
+  ROLEV @map("V")
+  ROLEW @map("W")
+  ROLEX @map("X")
+  ROLEY @map("Y")
+  ROLEZ @map("Z")
+}
+
+model MarketRole {
+  code        MarketParticipantRoleCode @id
+  description String
+
+  @@map("market_role")
+}
+
+model MarketParticipant {
+  id            String  @id
+  name          String
+  poolMemberId  String?
+  roles         MarketParticipantRole[]
+
+  @@map("market_participant")
+}
+
+model MarketParticipantRole {
+  marketParticipantId String
+  roleCode            MarketParticipantRoleCode
+  effectiveFrom       DateTime
+  effectiveTo         DateTime?
+  address1            String?
+  address2            String?
+  address3            String?
+  address4            String?
+  address5            String?
+  address6            String?
+  address7            String?
+  address8            String?
+  address9            String?
+  postCode            String?
+  distributorShortCode String?
+  marketParticipant   MarketParticipant @relation(fields: [marketParticipantId], references: [id])
+
+  @@id([marketParticipantId, roleCode, effectiveFrom])
+  @@map("market_participant_role")
+}
+
+model GspGroup {
+  id   String @id
+  name String
+
+  @@map("gsp_group")
+}
+
+model ProfileClass {
+  id                         Int      @id
+  effectiveFromSettlementDate DateTime
+  description                String
+  switchedLoadProfileClassInd Boolean
+  effectiveToSettlementDate   DateTime?
+
+  @@map("profile_class")
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,47 +14,8 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-enum MarketParticipantRoleCode {
-  ROLE0 @map("0")
-  ROLE1 @map("1")
-  ROLE2 @map("2")
-  ROLE3 @map("3")
-  ROLE4 @map("4")
-  ROLE5 @map("5")
-  ROLE6 @map("6")
-  ROLE7 @map("7")
-  ROLE8 @map("8")
-  ROLE9 @map("9")
-  ROLEA @map("A")
-  ROLEB @map("B")
-  ROLEC @map("C")
-  ROLED @map("D")
-  ROLEE @map("E")
-  ROLEF @map("F")
-  ROLEG @map("G")
-  ROLEH @map("H")
-  ROLEI @map("I")
-  ROLEJ @map("J")
-  ROLEK @map("K")
-  ROLEL @map("L")
-  ROLEM @map("M")
-  ROLEN @map("N")
-  ROLEO @map("O")
-  ROLEP @map("P")
-  ROLEQ @map("Q")
-  ROLER @map("R")
-  ROLES @map("S")
-  ROLET @map("T")
-  ROLEU @map("U")
-  ROLEV @map("V")
-  ROLEW @map("W")
-  ROLEX @map("X")
-  ROLEY @map("Y")
-  ROLEZ @map("Z")
-}
-
 model MarketRole {
-  code        MarketParticipantRoleCode @id
+  code        String @id @db.Char(1)
   description String
 
   @@map("market_role")
@@ -71,7 +32,8 @@ model MarketParticipant {
 
 model MarketParticipantRole {
   marketParticipantId String
-  roleCode            MarketParticipantRoleCode
+  roleCode            String
+  marketRole         MarketRole @relation(fields: [roleCode], references: [code])
   effectiveFrom       DateTime
   effectiveTo         DateTime?
   address1            String?
@@ -106,4 +68,53 @@ model ProfileClass {
   effectiveToSettlementDate   DateTime?
 
   @@map("profile_class")
+}
+
+model ValidMtcLlfcCombination {
+  meterTimeswitchClassId                String
+  meterTimeswitchClassEffectiveFrom     DateTime
+  marketParticipantId                   String
+  marketParticipantEffectiveFrom        DateTime
+  lineLossFactorClassId                 String
+  lineLossFactorClassEffectiveFrom      DateTime
+  effectiveTo                           DateTime?
+
+  @@id([
+    meterTimeswitchClassId,
+    meterTimeswitchClassEffectiveFrom,
+    marketParticipantId,
+    marketParticipantEffectiveFrom,
+    lineLossFactorClassId,
+    lineLossFactorClassEffectiveFrom
+  ])
+  @@map("valid_mtc_llfc_combination")
+}
+
+model ValidMtcLlfcSscPcCombination {
+  meterTimeswitchClassId                    String
+  meterTimeswitchClassEffectiveFrom         DateTime
+  marketParticipantId                       String
+  marketParticipantEffectiveFrom            DateTime
+  standardSettlementConfigurationId         String
+  standardSettlementConfigurationEffectiveFrom DateTime
+  lineLossFactorClassId                     String
+  lineLossFactorClassEffectiveFrom          DateTime
+  profileClassId                            Int
+  profileClassEffectiveFrom                 DateTime
+  effectiveTo                               DateTime?
+  preservedTariffIndicator                  String
+
+  @@id([
+    meterTimeswitchClassId,
+    meterTimeswitchClassEffectiveFrom,
+    marketParticipantId,
+    marketParticipantEffectiveFrom,
+    standardSettlementConfigurationId,
+    standardSettlementConfigurationEffectiveFrom,
+    lineLossFactorClassId,
+    lineLossFactorClassEffectiveFrom,
+    profileClassId,
+    profileClassEffectiveFrom
+  ])
+  @@map("valid_mtc_llfc_ssc_pc_combination")
 }


### PR DESCRIPTION
## Why

Sets up core database models so MDD data can be stored and queried via Prisma.

## Notes

`yarn lint --fix`, `yarn format`, `yarn ts:check` and tests failed due to missing workspace installation.

------
https://chatgpt.com/codex/tasks/task_e_684c775f238c8326867c3a5547ad8ba6

## Summary by Sourcery

New Features:
- Add initial Prisma schema with core database models for MDD data storage and querying

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new entities for managing market participants, their roles, and related groups and classifications.
	- Enhanced data structure to support detailed participant roles, groupings, and profile classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->