### PR TITLE
feat(ci): enable yarn cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'yarn'
+          cache-dependency-path: '**/yarn.lock'
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Lint
+        run: yarn lint --fix
+
+      - name: Format
+        run: yarn format
+
+      - name: Type check
+        run: yarn ts:check
+
+      - name: Unit tests
+        run: yarn nx run-many --target=test
+
+      - name: Test script
+        run: yarn test
+
+      - name: E2E tests
+        run: yarn e2e


### PR DESCRIPTION
## Why
Speeds up installs by caching dependencies during CI runs.

## Notes
- `yarn lint`, `yarn format`, `yarn ts:check`, `yarn test`, and `yarn e2e` are missing scripts.
- `yarn nx run-many --target=test` failed for `mdd-loader`.


------
https://chatgpt.com/codex/tasks/task_e_684d429583c08326be9bde97ced90c86