### PR TITLE
feat(loader): add JSDoc comments

### DIFF
--- a/apps/mdd-loader/src/main.ts
+++ b/apps/mdd-loader/src/main.ts
@@ -4,6 +4,12 @@ import { parseArgs } from 'node:util';
 import path from 'node:path';
 import { prisma, seed } from '../../../prisma/seed';
 
+/**
+ * Parse CLI arguments into options used by the seeder.
+ *
+ * @param argv - Arguments from the command line.
+ * @returns Object containing the directory path for seed files.
+ */
 export function parseOptions(argv: string[]): { dir: string } {
   const { values } = parseArgs({
     args: argv,
@@ -15,6 +21,12 @@ export function parseOptions(argv: string[]): { dir: string } {
   return { dir: values.dir };
 }
 
+/**
+ * Execute the seeding process from CLI arguments.
+ *
+ * @param argv - Arguments from the command line; defaults to `process.argv`.
+ * @returns Resolves when the seed completes or rejects on error.
+ */
 export async function main(argv: string[] = process.argv.slice(2)): Promise<void> {
   const { dir } = parseOptions(argv);
   const dataDir = path.resolve(dir);


### PR DESCRIPTION
## Why
Clarifies command usage for developers and keeps CLI helpers self-documenting.

## Notes
- `yarn lint --fix`, `yarn format`, and `yarn ts:check` scripts were missing, causing failures.
- `yarn nx run-many --target=test` failed as Prisma client was absent.

## Release
Label: `release:patch`

------
https://chatgpt.com/codex/tasks/task_e_684d576d5e608326a10a58e56bdb2998

## Summary by Sourcery

Add JSDoc comments to the loader's CLI functions to clarify argument parsing and seeding usage

Documentation:
- Document the parseOptions function with JSDoc for CLI argument parsing
- Document the main function with JSDoc for executing the seeding process