### PR TITLE
feat(prisma): add JSDoc for seed helpers

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -28,6 +28,12 @@ export async function seed(dir: string = path.join(__dirname, '..', 'data')): Pr
   }
 }
 
+/**
+ * Load Market Roles from the CSV drop.
+ *
+ * @param tx - Prisma transaction context
+ * @param dir - Directory containing the CSV files
+ */
 export async function seedMarketRoles(
   tx: Prisma.TransactionClient,
   dir: string,
@@ -40,6 +46,12 @@ export async function seedMarketRoles(
   });
 }
 
+/**
+ * Load Market Participants from the CSV drop.
+ *
+ * @param tx - Prisma transaction context
+ * @param dir - Directory containing the CSV files
+ */
 export async function seedMarketParticipants(
   tx: Prisma.TransactionClient,
   dir: string,
@@ -56,6 +68,12 @@ export async function seedMarketParticipants(
   });
 }
 
+/**
+ * Load Market Participant Roles from the CSV drop.
+ *
+ * @param tx - Prisma transaction context
+ * @param dir - Directory containing the CSV files
+ */
 export async function seedMarketParticipantRoles(
   tx: Prisma.TransactionClient,
   dir: string,
@@ -84,6 +102,12 @@ export async function seedMarketParticipantRoles(
   });
 }
 
+/**
+ * Load valid MTC to LLFC combinations from the CSV drop.
+ *
+ * @param tx - Prisma transaction context
+ * @param dir - Directory containing the CSV files
+ */
 export async function seedValidMtcLlfcCombinations(
   tx: Prisma.TransactionClient,
   dir: string,
@@ -104,6 +128,12 @@ export async function seedValidMtcLlfcCombinations(
   });
 }
 
+/**
+ * Load valid MTC/LLFC/SSC/PC combinations from the CSV drop.
+ *
+ * @param tx - Prisma transaction context
+ * @param dir - Directory containing the CSV files
+ */
 export async function seedValidMtcLlfcSscPcCombinations(
   tx: Prisma.TransactionClient,
   dir: string,
@@ -131,6 +161,11 @@ export async function seedValidMtcLlfcSscPcCombinations(
   });
 }
 
+/**
+ * Read a CSV file and return its rows.
+ *
+ * @param file - Full path to the CSV file
+ */
 export async function readCsv(file: string): Promise<string[][]> {
   try {
     const content = await fs.readFile(file, 'utf8');


### PR DESCRIPTION
## Why
Adds documentation for seed helper functions to aid maintainers.

## Testing
- `yarn lint --fix` *(fails: Couldn't find a script named "lint")*
- `yarn format` *(fails: Couldn't find a script named "format")*
- `yarn ts:check` *(fails: Couldn't find a script named "ts:check")*
- `yarn nx run-many --target=test` *(fails: mdd-loader test cannot find generated prisma)*

------
https://chatgpt.com/codex/tasks/task_e_684d5e38fe2483269bf60c094b5d3892