### PR TITLE
feat(repo): add e2e script

### DIFF
--- a/apps/mdd-loader/src/main.ts
+++ b/apps/mdd-loader/src/main.ts
@@ -2,7 +2,7 @@
 
 import { parseArgs } from 'node:util';
 import path from 'node:path';
-import { prisma, seed } from '../../../prisma/seed';
+import { prisma, seed } from 'prisma/seed';
 
 /**
  * Parse CLI arguments into options used by the seeder.
@@ -27,7 +27,9 @@ export function parseOptions(argv: string[]): { dir: string } {
  * @param argv - Arguments from the command line; defaults to `process.argv`.
  * @returns Resolves when the seed completes or rejects on error.
  */
-export async function main(argv: string[] = process.argv.slice(2)): Promise<void> {
+export async function main(
+  argv: string[] = process.argv.slice(2)
+): Promise<void> {
   const { dir } = parseOptions(argv);
   const dataDir = path.resolve(dir);
 
@@ -43,6 +45,5 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<void
 }
 
 if (require.main === module) {
-  // eslint-disable-next-line @typescript-eslint/no-floating-promises
   main();
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "author": "Kristian Matthews-Kennington <kristian@matthews-kennington.com>",
   "private": true,
   "scripts": {
-    "nx": "nx"
+    "nx": "nx",
+    "e2e": "nx run-many --target=e2e"
   },
   "engines": {
     "node": ">=22"

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,7 +15,8 @@
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
     "paths": {
-      "engine": ["packages/engine/src/index.ts"]
+      "engine": ["packages/engine/src/index.ts"],
+      "prisma/*": ["prisma/*"]
     }
   },
   "exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
## Summary
- expose `yarn e2e` to run all Playwright tests
- fix lint error by using alias for Prisma imports

## Why
Allow contributors to run all end-to-end tests easily.

## Notes
- lint passed but unit and e2e tests fail in the current repo.
- please label this PR with `release:patch`.


------
https://chatgpt.com/codex/tasks/task_e_684d714ebe8c8326bd8a177b21a9762f

## Summary by Sourcery

Expose a new "e2e" script for running all Playwright tests and resolve lint errors by aliasing Prisma imports

New Features:
- Add "e2e" script in package.json to run all end-to-end tests via NX

Enhancements:
- Use TypeScript path alias for Prisma imports to fix lint errors