### PR TITLE
feat(mdd-loader): add short flag test

### DIFF
--- a/apps/mdd-loader/src/main.spec.ts
+++ b/apps/mdd-loader/src/main.spec.ts
@@ -1,3 +1,8 @@
+jest.mock('../../../prisma/seed', () => ({
+  prisma: { $disconnect: jest.fn() },
+  seed: jest.fn(),
+}));
+
 import { parseOptions } from './main';
 
 describe('parseOptions', () => {
@@ -7,5 +12,9 @@ describe('parseOptions', () => {
 
   it('parses --dir flag', () => {
     expect(parseOptions(['--dir', 'foo'])).toEqual({ dir: 'foo' });
+  });
+
+  it('parses -d flag', () => {
+    expect(parseOptions(['-d', 'bar'])).toEqual({ dir: 'bar' });
   });
 });


### PR DESCRIPTION
## Why
- ensure CLI flags handle short aliases

## Notes
- `yarn lint --fix`, `yarn format`, and `yarn ts:check` scripts were missing so the commands failed
- unit tests run via `yarn nx run-many --target=test` succeeded

------
https://chatgpt.com/codex/tasks/task_e_684d6fc8979883268610693a1ed008b4

## Summary by Sourcery

Tests:
- Add unit test for parsing the '-d' short alias for the dir flag