### PR TITLE
feat(mdd-loader): add seed invocation test

### DIFF
--- a/apps/mdd-loader-e2e/src/mdd-loader/mdd-loader.spec.ts
+++ b/apps/mdd-loader-e2e/src/mdd-loader/mdd-loader.spec.ts
@@ -7,6 +7,6 @@ describe('CLI tests', () => {
 
     const output = execSync(`node ${cliPath}`).toString();
 
-    expect(output).toMatch(/✅ Seed completed/);
+    expect(output).toMatch(/✅ Seed completed from/);
   });
 });

--- a/apps/mdd-loader/src/seed.spec.ts
+++ b/apps/mdd-loader/src/seed.spec.ts
@@ -1,0 +1,34 @@
+import path from 'node:path';
+
+const seed = jest.fn();
+const disconnect = jest.fn();
+
+jest.mock('../../../prisma/seed', () => ({
+  prisma: { $disconnect: disconnect },
+  seed,
+}));
+
+describe('main', () => {
+  let main: typeof import('./main').main;
+
+  beforeAll(async () => {
+    ({ main } = await import('./main'));
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('invokes seed with resolved directory', async () => {
+    await main(['--dir', 'fixtures']);
+
+    expect(seed).toHaveBeenCalledWith(path.resolve('fixtures'));
+    expect(disconnect).toHaveBeenCalled();
+  });
+
+  it('uses default data directory', async () => {
+    await main();
+
+    expect(seed).toHaveBeenCalledWith(path.resolve('data'));
+  });
+});

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,6 +1,5 @@
 //@ts-check
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const { composePlugins, withNx } = require('@nx/next');
 
 /**


### PR DESCRIPTION
## Why
Ensure the CLI passes the correct directory to the Prisma seed script and update the end-to-end expectations accordingly.

## Changes
- added Jest test mocking Prisma client
- updated e2e assertion for new CLI success output
- formatted Next.js config

## Testing
- `yarn nx run-many --target=lint --fix`
- `yarn nx format:write`
- `yarn ts:check` *(fails: script not found)*
- `yarn nx run-many --target=test`

------
https://chatgpt.com/codex/tasks/task_e_684dcdd3d1a08326a8555ade1a44459e

## Summary by Sourcery

Add seed invocation tests, update end-to-end seed output assertion, and format Next.js config

Enhancements:
- Format Next.js configuration file to remove unused comment

Tests:
- Add Jest unit tests to verify seed invocation with correct directory and Prisma disconnection
- Update E2E test assertion to match updated CLI success output including directory in the seed message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test assertions for CLI output to check for a more specific message.
  - Added new tests to verify seeding behaviour with and without directory arguments.
- **Style**
  - Removed an ESLint directive comment from configuration for cleaner code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->