### PR TITLE
feat(engine): extract mdd loader

### DIFF
--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -6,6 +6,8 @@
   "main": "./src/index.js",
   "types": "./src/index.d.ts",
   "dependencies": {
-    "tslib": "^2.3.0"
+    "tslib": "^2.3.0",
+    "date-fns": "^4.1.0",
+    "csv-parse": "^5.6.0"
   }
 }

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -1,1 +1,2 @@
 export * from './lib/engine';
+export * from './lib/mdd-loader';

--- a/packages/engine/src/lib/mdd-loader.ts
+++ b/packages/engine/src/lib/mdd-loader.ts
@@ -1,0 +1,160 @@
+'use strict';
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { parse } from 'date-fns';
+import { parse as parseCsv } from 'csv-parse/sync';
+import { Prisma } from 'generated/prisma';
+
+/**
+ * Read a CSV file and return rows.
+ *
+ * @param file - Path to the CSV file.
+ * @returns Array of rows as string arrays.
+ */
+export async function readCsv(file: string): Promise<string[][]> {
+  try {
+    const content = await fs.readFile(file, 'utf8');
+    return parseCsv(content, { relaxQuotes: true });
+  } catch (err) {
+    console.error('Failed to read CSV:', file, err);
+    throw err;
+  }
+}
+
+/**
+ * Parse a date in dd/MM/yyyy format.
+ *
+ * @param value - Date string.
+ * @returns Parsed Date or null if invalid.
+ */
+export function parseDate(value: string | undefined): Date | null {
+  if (!value) return null;
+  try {
+    const date = parse(value, 'dd/MM/yyyy', new Date());
+    if (isNaN(date.getTime())) return null;
+    return new Date(
+      Date.UTC(date.getFullYear(), date.getMonth(), date.getDate())
+    );
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Seed Market Roles.
+ */
+export async function seedMarketRoles(
+  tx: Prisma.TransactionClient,
+  dir: string
+): Promise<void> {
+  const rows = await readCsv(path.join(dir, 'Market_Role.csv'));
+  rows.shift();
+  await tx.marketRole.createMany({
+    data: rows.map(([code, description]) => ({ code, description })),
+    skipDuplicates: true,
+  });
+}
+
+/**
+ * Seed Market Participants.
+ */
+export async function seedMarketParticipants(
+  tx: Prisma.TransactionClient,
+  dir: string
+): Promise<void> {
+  const rows = await readCsv(path.join(dir, 'Market_Participant.csv'));
+  rows.shift();
+  await tx.marketParticipant.createMany({
+    data: rows.map(([id, name, poolMemberId]) => ({
+      id,
+      name,
+      poolMemberId: poolMemberId || null,
+    })),
+    skipDuplicates: true,
+  });
+}
+
+/**
+ * Seed Market Participant Roles.
+ */
+export async function seedMarketParticipantRoles(
+  tx: Prisma.TransactionClient,
+  dir: string
+): Promise<void> {
+  const rows = await readCsv(path.join(dir, 'Market_Participant_Role.csv'));
+  rows.shift();
+  await tx.marketParticipantRole.createMany({
+    data: rows.map((r) => ({
+      marketParticipantId: r[0],
+      roleCode: r[1],
+      effectiveFrom: parseDate(r[2])!,
+      effectiveTo: parseDate(r[3]),
+      address1: r[4] || null,
+      address2: r[5] || null,
+      address3: r[6] || null,
+      address4: r[7] || null,
+      address5: r[8] || null,
+      address6: r[9] || null,
+      address7: r[10] || null,
+      address8: r[11] || null,
+      address9: r[12] || null,
+      postCode: r[13] || null,
+      distributorShortCode: r[14] || null,
+    })),
+    skipDuplicates: true,
+  });
+}
+
+/**
+ * Seed valid MTC/LLFC combinations.
+ */
+export async function seedValidMtcLlfcCombinations(
+  tx: Prisma.TransactionClient,
+  dir: string
+): Promise<void> {
+  const rows = await readCsv(path.join(dir, 'Valid_MTC_LLFC_Combination.csv'));
+  rows.shift();
+  await tx.validMtcLlfcCombination.createMany({
+    data: rows.map((r) => ({
+      meterTimeswitchClassId: r[0],
+      meterTimeswitchClassEffectiveFrom: parseDate(r[1])!,
+      marketParticipantId: r[2],
+      marketParticipantEffectiveFrom: parseDate(r[3])!,
+      lineLossFactorClassId: r[4],
+      lineLossFactorClassEffectiveFrom: parseDate(r[5])!,
+      effectiveTo: parseDate(r[6]),
+    })),
+    skipDuplicates: true,
+  });
+}
+
+/**
+ * Seed valid MTC/LLFC/SSC/PC combinations.
+ */
+export async function seedValidMtcLlfcSscPcCombinations(
+  tx: Prisma.TransactionClient,
+  dir: string
+): Promise<void> {
+  const rows = await readCsv(
+    path.join(dir, 'Valid_MTC_LLFC_SSC_PC_Combination.csv')
+  );
+  rows.shift();
+  await tx.validMtcLlfcSscPcCombination.createMany({
+    data: rows.map((r) => ({
+      meterTimeswitchClassId: r[0],
+      meterTimeswitchClassEffectiveFrom: parseDate(r[1])!,
+      marketParticipantId: r[2],
+      marketParticipantEffectiveFrom: parseDate(r[3])!,
+      standardSettlementConfigurationId: r[4],
+      standardSettlementConfigurationEffectiveFrom: parseDate(r[5])!,
+      lineLossFactorClassId: r[6],
+      lineLossFactorClassEffectiveFrom: parseDate(r[7])!,
+      profileClassId: Number(r[8]),
+      profileClassEffectiveFrom: parseDate(r[9])!,
+      effectiveTo: parseDate(r[10]),
+      preservedTariffIndicator: r[11],
+    })),
+    skipDuplicates: true,
+  });
+}

--- a/prisma/seed.spec.ts
+++ b/prisma/seed.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import path from 'node:path';
-import { parseDate, readCsv } from './seed';
+import { parseDate, readCsv } from 'engine';
 
 describe('parseDate', () => {
   it('parses dd/MM/yyyy', () => {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,17 +1,23 @@
 'use strict';
 
-import fs from 'node:fs/promises';
 import path from 'node:path';
-import { parse } from 'date-fns';
-import { parse as parseCsv } from 'csv-parse/sync';
 import { PrismaClient, Prisma } from '../generated/prisma';
+import {
+  seedMarketParticipantRoles,
+  seedMarketParticipants,
+  seedMarketRoles,
+  seedValidMtcLlfcCombinations,
+  seedValidMtcLlfcSscPcCombinations,
+} from 'engine';
 
 export const prisma = new PrismaClient();
 
 /**
  * Seed the database with Market Domain Data from CSV files.
  */
-export async function seed(dir: string = path.join(__dirname, '..', 'data')): Promise<void> {
+export async function seed(
+  dir: string = path.join(__dirname, '..', 'data')
+): Promise<void> {
   const dataDir = dir;
 
   try {
@@ -25,135 +31,6 @@ export async function seed(dir: string = path.join(__dirname, '..', 'data')): Pr
   } catch (err) {
     console.error('❌ Seed failed:', err);
     throw err;
-  }
-}
-
-export async function seedMarketRoles(
-  tx: Prisma.TransactionClient,
-  dir: string,
-): Promise<void> {
-  const rows = await readCsv(path.join(dir, 'Market_Role.csv'));
-  rows.shift();
-  await tx.marketRole.createMany({
-    data: rows.map(([code, description]) => ({ code, description })),
-    skipDuplicates: true,
-  });
-}
-
-export async function seedMarketParticipants(
-  tx: Prisma.TransactionClient,
-  dir: string,
-): Promise<void> {
-  const rows = await readCsv(path.join(dir, 'Market_Participant.csv'));
-  rows.shift();
-  await tx.marketParticipant.createMany({
-    data: rows.map(([id, name, poolMemberId]) => ({
-      id,
-      name,
-      poolMemberId: poolMemberId || null,
-    })),
-    skipDuplicates: true,
-  });
-}
-
-export async function seedMarketParticipantRoles(
-  tx: Prisma.TransactionClient,
-  dir: string,
-): Promise<void> {
-  const rows = await readCsv(path.join(dir, 'Market_Participant_Role.csv'));
-  rows.shift();
-  await tx.marketParticipantRole.createMany({
-    data: rows.map((r) => ({
-      marketParticipantId: r[0],
-      roleCode: r[1],
-      effectiveFrom: parseDate(r[2])!,
-      effectiveTo: parseDate(r[3]),
-      address1: r[4] || null,
-      address2: r[5] || null,
-      address3: r[6] || null,
-      address4: r[7] || null,
-      address5: r[8] || null,
-      address6: r[9] || null,
-      address7: r[10] || null,
-      address8: r[11] || null,
-      address9: r[12] || null,
-      postCode: r[13] || null,
-      distributorShortCode: r[14] || null,
-    })),
-    skipDuplicates: true,
-  });
-}
-
-export async function seedValidMtcLlfcCombinations(
-  tx: Prisma.TransactionClient,
-  dir: string,
-): Promise<void> {
-  const rows = await readCsv(path.join(dir, 'Valid_MTC_LLFC_Combination.csv'));
-  rows.shift();
-  await tx.validMtcLlfcCombination.createMany({
-    data: rows.map((r) => ({
-      meterTimeswitchClassId: r[0],
-      meterTimeswitchClassEffectiveFrom: parseDate(r[1])!,
-      marketParticipantId: r[2],
-      marketParticipantEffectiveFrom: parseDate(r[3])!,
-      lineLossFactorClassId: r[4],
-      lineLossFactorClassEffectiveFrom: parseDate(r[5])!,
-      effectiveTo: parseDate(r[6]),
-    })),
-    skipDuplicates: true,
-  });
-}
-
-export async function seedValidMtcLlfcSscPcCombinations(
-  tx: Prisma.TransactionClient,
-  dir: string,
-): Promise<void> {
-  const rows = await readCsv(
-    path.join(dir, 'Valid_MTC_LLFC_SSC_PC_Combination.csv'),
-  );
-  rows.shift();
-  await tx.validMtcLlfcSscPcCombination.createMany({
-    data: rows.map((r) => ({
-      meterTimeswitchClassId: r[0],
-      meterTimeswitchClassEffectiveFrom: parseDate(r[1])!,
-      marketParticipantId: r[2],
-      marketParticipantEffectiveFrom: parseDate(r[3])!,
-      standardSettlementConfigurationId: r[4],
-      standardSettlementConfigurationEffectiveFrom: parseDate(r[5])!,
-      lineLossFactorClassId: r[6],
-      lineLossFactorClassEffectiveFrom: parseDate(r[7])!,
-      profileClassId: Number(r[8]),
-      profileClassEffectiveFrom: parseDate(r[9])!,
-      effectiveTo: parseDate(r[10]),
-      preservedTariffIndicator: r[11],
-    })),
-    skipDuplicates: true,
-  });
-}
-
-export async function readCsv(file: string): Promise<string[][]> {
-  try {
-    const content = await fs.readFile(file, 'utf8');
-    return parseCsv(content, { relaxQuotes: true });
-  } catch (err) {
-    console.error('Failed to read CSV:', file, err);
-    throw err;
-  }
-}
-
-/**
- * Parse a date in dd/MM/yyyy format.
- */
-export function parseDate(value: string | undefined): Date | null {
-  if (!value) return null;
-  try {
-    const date = parse(value, 'dd/MM/yyyy', new Date());
-    if (isNaN(date.getTime())) return null;
-    return new Date(
-      Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()),
-    );
-  } catch {
-    return null;
   }
 }
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,7 +15,8 @@
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
     "paths": {
-      "engine": ["packages/engine/src/index.ts"]
+      "engine": ["packages/engine/src/index.ts"],
+      "generated/prisma": ["generated/prisma.ts"]
     }
   },
   "exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
## Why
Reuse MDD seed helpers across packages.

## Changes
- move CSV utilities and seed helpers to `engine`
- expose helpers from engine index
- update prisma seed and specs
- alias generated client in tsconfig

## Testing
- `yarn nx run-many --target=lint --fix`
- `yarn nx test engine --output-style=stream`
- `yarn nx test mdd-loader --output-style=stream`
- `yarn nx test web --output-style=stream`


------
https://chatgpt.com/codex/tasks/task_e_684ddd806a748326bddd27cd62721adb