### PR TITLE
feat(docs): add MDD loader section

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,5 +32,4 @@ Ensure the database connection variables are set before running:
 yarn nx serve mdd-loader -- --dir=./data
 ```
 
-It runs via the read-only Prisma client in line with the
-[AGENTS guidelines](./AGENTS.md).
+It runs via the project's read-only Prisma client.

--- a/README.md
+++ b/README.md
@@ -23,3 +23,14 @@ Execute `yarn nx run-many --target=test` and `yarn test` to verify behaviour.
 Use the PR title pattern `feat(scope): summary` and label your PR with
 `release:patch`, `release:minor` or `release:major`.
 
+## MDD Loader
+
+The loader ingests the monthly CSV drop located in `data/`.
+Ensure the database connection variables are set before running:
+
+```bash
+yarn nx serve mdd-loader -- --dir=./data
+```
+
+It runs via the read-only Prisma client in line with the
+[AGENTS guidelines](./AGENTS.md).


### PR DESCRIPTION
## Why
- document how to run the MDD loader

## Notes
- `yarn ts:check`, `yarn format` and `yarn test` scripts were missing

------
https://chatgpt.com/codex/tasks/task_e_684f216875388326835f2c6c6d21f265

## Summary by Sourcery

Documentation:
- Add an 'MDD Loader' section with instructions for ingesting CSV data and running the loader via Yarn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a "MDD Loader" section to the README, detailing how to run the loader, required environment setup, and its usage guidelines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->