### PR TITLE
feat(web): add version API

### DIFF
--- a/apps/web/src/app/api/version/route.spec.ts
+++ b/apps/web/src/app/api/version/route.spec.ts
@@ -1,6 +1,6 @@
 import { Response } from 'node-fetch';
 import { GET } from './route';
-import pkg from '../../../../../../package.json';
+import pkg from 'root/pkg';
 
 if (typeof globalThis.Response === 'undefined') {
   // Polyfill for Node.js test environment

--- a/apps/web/src/app/api/version/route.spec.ts
+++ b/apps/web/src/app/api/version/route.spec.ts
@@ -1,0 +1,18 @@
+import { Response } from 'node-fetch';
+import { GET } from './route';
+import pkg from '../../../../../../package.json';
+
+if (typeof globalThis.Response === 'undefined') {
+  // Polyfill for Node.js test environment
+  // eslint-disable-next-line no-global-assign
+  (globalThis as any).Response = Response;
+}
+
+describe('version API', () => {
+  it('returns package version', async () => {
+    const res = await GET();
+    expect(res.headers.get('content-type')).toMatch('application/json');
+    const data = await res.json();
+    expect(data).toEqual({ version: pkg.version });
+  });
+});

--- a/apps/web/src/app/api/version/route.ts
+++ b/apps/web/src/app/api/version/route.ts
@@ -1,4 +1,4 @@
-import pkg from '../../../../../../package.json';
+import pkg from 'root/pkg';
 
 /**
  * Return the current application version.

--- a/apps/web/src/app/api/version/route.ts
+++ b/apps/web/src/app/api/version/route.ts
@@ -1,0 +1,10 @@
+import pkg from '../../../../../../package.json';
+
+/**
+ * Return the current application version.
+ */
+export async function GET() {
+  return new Response(JSON.stringify({ version: pkg.version }), {
+    headers: { 'content-type': 'application/json' },
+  });
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
   "scripts": {
     "nx": "nx",
     "e2e": "nx run-many --target=e2e",
-    "lint": "nx run mdd-loader:lint"
+    "lint": "nx run mdd-loader:lint",
+    "format": "prettier --write apps/web/src/app/api/version package.json",
+    "ts:check": "tsc -p apps/web/tsconfig.json --noEmit && tsc -p packages/engine/tsconfig.json --noEmit && tsc -p prisma/tsconfig.json --noEmit",
+    "test": "nx run-many --target=test"
   },
   "engines": {
     "node": ">=22"

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -16,7 +16,8 @@
     "baseUrl": ".",
     "paths": {
       "engine": ["packages/engine/src/index.ts"],
-      "generated/prisma": ["generated/prisma.ts"]
+      "generated/prisma": ["generated/prisma.ts"],
+      "root/pkg": ["package.json"]
     }
   },
   "exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
## Why
Provide a simple endpoint showing the app version for diagnostics.

## Notes
- Added `format`, `ts:check` and `test` scripts for repo commands.
- New Jest test validates the API route.

------
https://chatgpt.com/codex/tasks/task_e_684f2d04dcd8832683b1c1a1649c6292

## Summary by Sourcery

Expose a new /api/version endpoint for diagnostics and configure related scripts and tests

New Features:
- Add a version API endpoint that returns the current application version

Build:
- Add format, ts:check, and test scripts to package.json for repository commands

Tests:
- Add a Jest test to validate the version API route returns the expected JSON

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added an API endpoint to retrieve the current application version.
- **Tests**
	- Introduced tests for the version API endpoint to ensure correct response and content.
- **Chores**
	- Added scripts for formatting, type checking, and running tests.
	- Updated TypeScript configuration with a new path alias for the package version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->