### PR TITLE
feat(repo): add tsconfig base check

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "e2e": "nx run-many --target=e2e",
     "lint": "nx run mdd-loader:lint",
     "format": "prettier --write apps/web/src/app/api/version package.json",
-    "ts:check": "tsc -p apps/web/tsconfig.json --noEmit && tsc -p packages/engine/tsconfig.json --noEmit && tsc -p prisma/tsconfig.json --noEmit",
+    "ts:check": "tsc --noEmit -p tsconfig.base.json",
     "test": "nx run-many --target=test"
   },
   "engines": {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -11,6 +11,10 @@
     "target": "es2015",
     "module": "esnext",
     "lib": ["es2020", "dom"],
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
@@ -20,5 +24,13 @@
       "root/pkg": ["package.json"]
     }
   },
-  "exclude": ["node_modules", "tmp"]
+  "exclude": [
+    "node_modules",
+    "tmp",
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/vitest.config.ts",
+    "**/*.test.ts",
+    "**/*.test.tsx"
+  ]
 }


### PR DESCRIPTION
## Why
Ensure consistent TypeScript settings across the monorepo.

## Testing
- `yarn lint --fix`
- `yarn format`
- `yarn ts:check`
- `CI=1 yarn test --maxWorkers=2`


------
https://chatgpt.com/codex/tasks/task_e_684f489c33048326819f484fb35e2ffb

## Summary by Sourcery

Add a base TypeScript configuration and simplify the ts:check script to use tsconfig.base.json for consistent type checking across the monorepo

Enhancements:
- Introduce tsconfig.base.json to centralize TypeScript settings across the monorepo
- Simplify the ts:check package script to perform a single type check against tsconfig.base.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Streamlined TypeScript type-checking by consolidating multiple scripts into a single command.
	- Updated TypeScript configuration to improve compatibility with React, module imports, and JSON files.
	- Enhanced exclusion patterns to better ignore test files and specific configurations during type-checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->