### PR TITLE
feat(ci): install playwright browsers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
 
+      - name: Install Playwright browsers
+        run: yarn playwright install --with-deps
+
       - name: Lint
         run: yarn lint --fix
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@
 
 1. Open the repository in VS Code, and select **Reopen in Container**.
 2. Wait for dependencies to install with Yarn.
-3. Ports `3000` and `6006` are forwarded.
-4. Formatting, linting, and type checks run automatically after creation.
-5. The Nx CLI is installed globally with Yarn so you can run `nx` directly.
+3. Run `yarn playwright install --with-deps` to fetch the required browsers.
+4. Ports `3000` and `6006` are forwarded.
+5. Formatting, linting, and type checks run automatically after creation.
+6. The Nx CLI is installed globally with Yarn so you can run `nx` directly.
 
 ## Project Goals
 


### PR DESCRIPTION
## Why
- run Playwright tests without manual browser setup

## What
- install Playwright browsers in CI
- document the installation step in the README


------
https://chatgpt.com/codex/tasks/task_e_684fc73b87fc8326b768c5756f476510