### PR TITLE
feat(ci): install Playwright browsers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
 
+      - name: Install Playwright browsers
+        run: yarn playwright install --with-deps
+
       - name: Lint
         run: yarn lint --fix
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@
 
 1. Open the repository in VS Code, and select **Reopen in Container**.
 2. Wait for dependencies to install with Yarn.
-3. Ports `3000` and `6006` are forwarded.
-4. Formatting, linting, and type checks run automatically after creation.
-5. The Nx CLI is installed globally with Yarn so you can run `nx` directly.
+3. Run `yarn playwright install --with-deps` inside the dev container to download required browsers.
+4. Ports `3000` and `6006` are forwarded.
+5. Formatting, linting, and type checks run automatically after creation.
+6. The Nx CLI is installed globally with Yarn so you can run `nx` directly.
 
 ## Project Goals
 


### PR DESCRIPTION
## Why
Ensure Playwright tests run with the required browsers.

## Changes
- install browsers in CI after dependencies
- document Playwright installation step for dev container

## Testing
- `yarn lint --fix`
- `yarn format`
- `yarn ts:check`
- `yarn nx run-many --target=test`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_685044d36c5c832686c080628d6c7eea

## Summary by Sourcery

Ensure Playwright browsers are installed in CI and the development container to support automated Playwright tests

CI:
- Install Playwright browsers after dependencies in the CI workflow

Documentation:
- Add README step to run `yarn playwright install --with-deps` in the dev container

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated CI workflow to install Playwright browsers and dependencies during the build process.

- **Documentation**
  - Updated setup instructions in the README to include a step for installing Playwright browsers within the development container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->