### PR TITLE
feat(dev): install Playwright browsers postinstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 1. Open the repository in VS Code, and select **Reopen in Container**.
 2. Wait for dependencies to install with Yarn.
-3. Run `yarn playwright install --with-deps` inside the dev container to download required browsers.
+3. Browsers install automatically after `yarn install` thanks to the `postinstall` script.
+   Run `yarn playwright install --with-deps` if you need to reinstall them manually.
 4. Ports `3000` and `6006` are forwarded.
 5. Formatting, linting, and type checks run automatically after creation.
 6. The Nx CLI is installed globally with Yarn so you can run `nx` directly.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "nx run mdd-loader:lint",
     "format": "prettier --write apps/web/src/app/api/version package.json",
     "ts:check": "tsc -p apps/web/tsconfig.json --noEmit && tsc -p packages/engine/tsconfig.json --noEmit && tsc -p prisma/tsconfig.json --noEmit",
-    "test": "nx run-many --target=test"
+    "test": "nx run-many --target=test",
+    "postinstall": "playwright install"
   },
   "engines": {
     "node": ">=22"


### PR DESCRIPTION
## Why
- ensure required browsers for Playwright tests install automatically

## Notes
- `yarn e2e` failed in the environment; see logs

Labels: release:patch

------
https://chatgpt.com/codex/tasks/task_e_685123e3060c8326b071cf129ae004e7

## Summary by Sourcery

Add a postinstall script to install Playwright browsers automatically and update documentation to describe the new installation behavior

New Features:
- Automatically install Playwright browsers after dependency installation via a postinstall script

Documentation:
- Update README to reflect automatic Playwright browser installation and provide manual reinstall instructions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Playwright browsers now install automatically after dependencies are installed, streamlining the setup process.
  - Updated documentation to reflect the new automated browser installation and clarified manual installation steps as a fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->