### PR TITLE
feat(ci): unify type checking

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "e2e": "nx run-many --target=e2e",
     "lint": "nx run mdd-loader:lint",
     "format": "prettier --write apps/web/src/app/api/version package.json",
-    "ts:check": "tsc -p apps/web/tsconfig.json --noEmit && tsc -p packages/engine/tsconfig.json --noEmit && tsc -p prisma/tsconfig.json --noEmit",
+    "ts:check": "tsc --noEmit -p tsconfig.base.json",
     "test": "nx run-many --target=test",
     "postinstall": "playwright install"
   },

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -10,6 +10,10 @@
     "importHelpers": true,
     "target": "es2015",
     "module": "esnext",
+    "jsx": "preserve",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
     "lib": ["es2020", "dom"],
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
@@ -20,5 +24,13 @@
       "root/pkg": ["package.json"]
     }
   },
-  "exclude": ["node_modules", "tmp"]
+  "exclude": [
+    "node_modules",
+    "tmp",
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "prisma/vitest.config.ts"
+  ]
 }


### PR DESCRIPTION
## Why
Ensures CI uses a single TypeScript config for consistency.

## Summary
- run `tsc` against `tsconfig.base.json`
- broaden root tsconfig options and exclude test files

## Testing
- `yarn lint --fix`
- `yarn format`
- `yarn ts:check`
- `yarn nx run-many --target=test`


------
https://chatgpt.com/codex/tasks/task_e_685130f57fe88326898f91a8705cd85a

## Summary by Sourcery

Consolidate TypeScript type checking to use a single shared configuration (tsconfig.base.json) by updating the ts:check script and enhancing the root tsconfig.

Enhancements:
- Broaden root TypeScript configuration to exclude test files and centralize shared options.

Build:
- Simplify the ts:check script to run type checking against tsconfig.base.json only.

CI:
- Unify CI type checking to use a single tsconfig.base.json configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Simplified and consolidated the TypeScript type checking process into a single command.
	- Updated TypeScript configuration to improve module compatibility, support JSX, and allow importing JSON files.
	- Expanded exclusions in the TypeScript configuration to omit test files and specific configuration files from compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->