### PR TITLE
feat(build): add prisma seed alias

### DIFF
--- a/apps/mdd-loader/src/main.ts
+++ b/apps/mdd-loader/src/main.ts
@@ -1,9 +1,9 @@
 'use strict';
-/* eslint-disable @nx/enforce-module-boundaries */
+ 
 
 import { parseArgs } from 'node:util';
 import path from 'node:path';
-import { prisma, seed } from '../../../prisma/seed';
+import { prisma, seed } from 'prisma/seed';
 
 /**
  * Parse CLI arguments into options used by the seeder.

--- a/apps/mdd-loader/src/seed.spec.ts
+++ b/apps/mdd-loader/src/seed.spec.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 const seed = jest.fn();
 const disconnect = jest.fn();
 
-jest.mock('../../../prisma/seed', () => ({
+jest.mock('prisma/seed', () => ({
   prisma: { $disconnect: disconnect },
   seed,
 }));

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -21,6 +21,7 @@
     "paths": {
       "engine": ["packages/engine/src/index.ts"],
       "generated/prisma": ["generated/prisma.ts"],
+      "prisma/seed": ["prisma/seed.ts"],
       "root/pkg": ["package.json"]
     }
   },


### PR DESCRIPTION
## Why
- allow mdd-loader to import seed using tsconfig path

## Notes
- lint, format and type-check executed
- dev server failed to start due to schema argument issue

------
https://chatgpt.com/codex/tasks/task_e_68513d94e7248326943a3fd6abfa0c86

## Summary by Sourcery

Introduce a TypeScript path alias for Prisma seed and update mdd-loader imports to use the new alias

Enhancements:
- Add a "prisma/seed" path mapping in tsconfig.base.json for absolute imports
- Update seed import in apps/mdd-loader/src/main.ts to use the new alias
- Update jest.mock in apps/mdd-loader/src/seed.spec.ts to reference "prisma/seed" instead of the relative path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated import paths for improved module resolution.
  - Introduced a new TypeScript path alias for easier referencing of the seed module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->