### PR TITLE
feat(mdd-loader): register tsconfig paths

### DIFF
--- a/apps/mdd-loader/project.json
+++ b/apps/mdd-loader/project.json
@@ -7,16 +7,22 @@
   "targets": {
     "build": {
       "executor": "@nx/esbuild:esbuild",
-      "outputs": ["{options.outputPath}"],
+      "outputs": [
+        "{options.outputPath}"
+      ],
       "defaultConfiguration": "production",
       "options": {
         "platform": "node",
         "outputPath": "dist/apps/mdd-loader",
-        "format": ["cjs"],
+        "format": [
+          "cjs"
+        ],
         "bundle": false,
         "main": "apps/mdd-loader/src/main.ts",
         "tsConfig": "apps/mdd-loader/tsconfig.app.json",
-        "assets": ["apps/mdd-loader/src/assets"],
+        "assets": [
+          "apps/mdd-loader/src/assets"
+        ],
         "generatePackageJson": true,
         "esbuildOptions": {
           "sourcemap": true,
@@ -41,10 +47,16 @@
       "continuous": true,
       "executor": "@nx/js:node",
       "defaultConfiguration": "development",
-      "dependsOn": ["build"],
+      "dependsOn": [
+        "build"
+      ],
       "options": {
         "buildTarget": "mdd-loader:build",
-        "runBuildTargetDependencies": false
+        "runBuildTargetDependencies": false,
+        "runtimeArgs": [
+          "-r",
+          "tsconfig-paths/register"
+        ]
       },
       "configurations": {
         "development": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "ts-node": "10.9.1",
     "tslib": "^2.3.0",
     "typescript": "~5.8.2",
-    "typescript-eslint": "^8.29.0"
+    "typescript-eslint": "^8.29.0",
+    "tsconfig-paths": "^4.2.0"
   },
   "dependencies": {
     "axios": "^1.6.0",


### PR DESCRIPTION
## Why
Ensure runtime resolves TS path aliases, fixing module resolution errors.

## Notes
- Added `tsconfig-paths` as dev dependency
- Updated `mdd-loader` serve target to preload paths
- Verified tests and lint pass


------
https://chatgpt.com/codex/tasks/task_e_685160494590832681fdca7d683c30ba

## Summary by Sourcery

New Features:
- Register tsconfig-paths to resolve TypeScript path aliases in mdd-loader

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved readability of project configuration files by reformatting arrays.
  - Added new runtime arguments to enhance application startup.
  - Introduced "tsconfig-paths" as a development dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->