### PR TITLE
feat(prisma): add Nx library

### DIFF
--- a/apps/mdd-loader/project.json
+++ b/apps/mdd-loader/project.json
@@ -7,6 +7,7 @@
   "targets": {
     "build": {
       "executor": "@nx/esbuild:esbuild",
+      "dependsOn": ["prisma:build"],
       "outputs": [
         "{options.outputPath}"
       ],

--- a/apps/mdd-loader/src/main.ts
+++ b/apps/mdd-loader/src/main.ts
@@ -3,7 +3,7 @@
 
 import { parseArgs } from 'node:util';
 import path from 'node:path';
-import { prisma, seed } from 'prisma/seed';
+import { prisma, seed } from 'prisma';
 
 /**
  * Parse CLI arguments into options used by the seeder.

--- a/apps/mdd-loader/src/seed.spec.ts
+++ b/apps/mdd-loader/src/seed.spec.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 const seed = jest.fn();
 const disconnect = jest.fn();
 
-jest.mock('prisma/seed', () => ({
+jest.mock('prisma', () => ({
   prisma: { $disconnect: disconnect },
   seed,
 }));

--- a/prisma/package.json
+++ b/prisma/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "prisma",
+  "version": "0.0.1",
+  "private": true,
+  "type": "commonjs",
+  "main": "./seed.js",
+  "types": "./seed.d.ts",
+  "dependencies": {
+    "tslib": "^2.3.0"
+  }
+}

--- a/prisma/project.json
+++ b/prisma/project.json
@@ -1,0 +1,17 @@
+{
+  "name": "prisma",
+  "$schema": "../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "prisma",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/prisma",
+        "main": "prisma/seed.ts",
+        "tsConfig": "prisma/tsconfig.lib.json"
+      }
+    }
+  }
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -21,6 +21,7 @@
     "paths": {
       "engine": ["packages/engine/src/index.ts"],
       "generated/prisma": ["generated/prisma.ts"],
+      "prisma": ["prisma/seed.ts"],
       "prisma/seed": ["prisma/seed.ts"],
       "root/pkg": ["package.json"]
     }


### PR DESCRIPTION
## Why
- share seed logic via a buildable library
- ensure mdd-loader uses compiled prisma assets

## What
- add `prisma` library with tsc build
- wire mdd-loader build to depend on it
- update imports and tsconfig path

------
https://chatgpt.com/codex/tasks/task_e_68516b5289f08326ac18c0ea545072f6