### PR TITLE
feat(ci): cover all projects

### DIFF
--- a/apps/web/src/app/api/hello/route.spec.ts
+++ b/apps/web/src/app/api/hello/route.spec.ts
@@ -4,11 +4,9 @@ import { GET } from './route';
 
 if (typeof globalThis.Response === 'undefined') {
   // Polyfill for Node.js test environment
-  // eslint-disable-next-line no-global-assign
   (globalThis as any).Response = Response;
 }
 if (typeof globalThis.Request === 'undefined') {
-  // eslint-disable-next-line no-global-assign
   (globalThis as any).Request = Request;
 }
 

--- a/apps/web/src/app/api/version/route.spec.ts
+++ b/apps/web/src/app/api/version/route.spec.ts
@@ -4,7 +4,6 @@ import pkg from 'root/pkg';
 
 if (typeof globalThis.Response === 'undefined') {
   // Polyfill for Node.js test environment
-  // eslint-disable-next-line no-global-assign
   (globalThis as any).Response = Response;
 }
 

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "nx": "nx",
     "e2e": "nx run-many --target=e2e",
-    "lint": "nx run mdd-loader:lint",
-    "format": "prettier --write apps/web/src/app/api/version package.json",
+    "lint": "nx run-many --target=lint",
+    "format": "prettier --write .",
     "ts:check": "tsc --noEmit -p tsconfig.base.json",
     "test": "nx run-many --target=test",
     "postinstall": "playwright install"

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 import path from 'node:path';
-import { PrismaClient, Prisma } from '../generated/prisma';
+import { PrismaClient, Prisma } from 'generated/prisma';
 import {
   seedMarketParticipantRoles,
   seedMarketParticipants,


### PR DESCRIPTION
## Why
- align scripts with NX monorepo setup
- ensure linting covers every project

## Changes
- run lint for all projects via `nx run-many`
- apply prettier over entire repository
- fix broken path in `prisma/seed.ts`
- clean up test setup comments


------
https://chatgpt.com/codex/tasks/task_e_68517d948a008326bc6c932ba92b3c2b

## Summary by Sourcery

Align lint and format scripts with the NX monorepo setup to cover all projects, fix the Prisma seed script path, and clean up test setup comments.

Bug Fixes:
- Fix broken import path in prisma/seed.ts

CI:
- Unify lint script to run across all projects using nx run-many
- Expand format script to apply Prettier across the entire repository

Tests:
- Remove redundant ESLint disable comments in API route test specs

Chores:
- Apply Prettier formatting to the entire codebase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated lint and format scripts to cover all projects and files for improved consistency.
  - Removed unnecessary ESLint directive comments from test files.
  - Updated import paths for database client modules to use non-relative paths for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->