### PR TITLE
feat(web): remove node-fetch polyfills from API tests

### DIFF
--- a/apps/web/src/app/api/hello/route.spec.ts
+++ b/apps/web/src/app/api/hello/route.spec.ts
@@ -1,22 +1,11 @@
-import { Request, Response } from 'node-fetch';
-import { waitFor } from '@testing-library/react';
+/**
+ * @jest-environment node
+ */
 import { GET } from './route';
-
-if (typeof globalThis.Response === 'undefined') {
-  // Polyfill for Node.js test environment
-  (globalThis as any).Response = Response;
-}
-if (typeof globalThis.Request === 'undefined') {
-  (globalThis as any).Request = Request;
-}
 
 describe('hello API', () => {
   it('returns greeting text', async () => {
     const res = await GET(new Request('http://localhost'));
-    await waitFor(async () => {
-      await expect(res.text()).resolves.toBe(
-        'Hello, from electric MDD UK API!'
-      );
-    });
+    await expect(res.text()).resolves.toBe('Hello, from electric MDD UK API!');
   });
 });

--- a/apps/web/src/app/api/version/route.spec.ts
+++ b/apps/web/src/app/api/version/route.spec.ts
@@ -1,11 +1,8 @@
-import { Response } from 'node-fetch';
+/**
+ * @jest-environment node
+ */
 import { GET } from './route';
 import pkg from 'root/pkg';
-
-if (typeof globalThis.Response === 'undefined') {
-  // Polyfill for Node.js test environment
-  (globalThis as any).Response = Response;
-}
 
 describe('version API', () => {
   it('returns package version', async () => {


### PR DESCRIPTION
## Why
- Node 20 includes `fetch`, `Request`, and `Response` globally
- tests no longer need `node-fetch` or manual polyfills

## Notes
- updated API route tests to run under the Node environment


------
https://chatgpt.com/codex/tasks/task_e_6851cc09ae988326b2bd18070e2da926

## Summary by Sourcery

Use Node 20’s built-in fetch implementation for API tests by removing manual polyfills, enabling the Node Jest environment, and cleaning up redundant waitFor code.

Enhancements:
- Remove node-fetch polyfills for Request and Response in API route tests
- Add @jest-environment node directive to API route tests
- Simplify response assertions by removing unnecessary waitFor

Tests:
- Annotate hello and version API tests to run under the Node Jest environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved reliability and clarity of API route tests by specifying the Node environment and simplifying test setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->