### PR TITLE
feat(engine): type prisma transaction client

### DIFF
--- a/packages/engine/generated/prisma.d.ts
+++ b/packages/engine/generated/prisma.d.ts
@@ -1,10 +1,71 @@
-/* eslint-disable */
 export class PrismaClient {
   $disconnect(): Promise<void>;
   $transaction<T>(fn: (tx: Prisma.TransactionClient) => Promise<T>): Promise<T>;
 }
 export namespace Prisma {
+  interface MarketRole {
+    code: string;
+    description: string;
+  }
+
+  interface MarketParticipant {
+    id: string;
+    name: string;
+    poolMemberId: string | null;
+  }
+
+  interface MarketParticipantRole {
+    marketParticipantId: string;
+    roleCode: string;
+    effectiveFrom: Date;
+    effectiveTo: Date | null;
+    address1: string | null;
+    address2: string | null;
+    address3: string | null;
+    address4: string | null;
+    address5: string | null;
+    address6: string | null;
+    address7: string | null;
+    address8: string | null;
+    address9: string | null;
+    postCode: string | null;
+    distributorShortCode: string | null;
+  }
+
+  interface ValidMtcLlfcCombination {
+    meterTimeswitchClassId: string;
+    meterTimeswitchClassEffectiveFrom: Date;
+    marketParticipantId: string;
+    marketParticipantEffectiveFrom: Date;
+    lineLossFactorClassId: string;
+    lineLossFactorClassEffectiveFrom: Date;
+    effectiveTo: Date | null;
+  }
+
+  interface ValidMtcLlfcSscPcCombination {
+    meterTimeswitchClassId: string;
+    meterTimeswitchClassEffectiveFrom: Date;
+    marketParticipantId: string;
+    marketParticipantEffectiveFrom: Date;
+    standardSettlementConfigurationId: string;
+    standardSettlementConfigurationEffectiveFrom: Date;
+    lineLossFactorClassId: string;
+    lineLossFactorClassEffectiveFrom: Date;
+    profileClassId: number;
+    profileClassEffectiveFrom: Date;
+    effectiveTo: Date | null;
+    preservedTariffIndicator: string;
+  }
+
+  interface Delegate<T> {
+    createMany(args: { data: T[]; skipDuplicates?: boolean }): Promise<void>;
+  }
+
   class TransactionClient {
-    [key: string]: any;
+    marketRole: Delegate<MarketRole>;
+    marketParticipant: Delegate<MarketParticipant>;
+    marketParticipantRole: Delegate<MarketParticipantRole>;
+    validMtcLlfcCombination: Delegate<ValidMtcLlfcCombination>;
+    validMtcLlfcSscPcCombination: Delegate<ValidMtcLlfcSscPcCombination>;
   }
 }

--- a/packages/engine/generated/prisma.ts
+++ b/packages/engine/generated/prisma.ts
@@ -8,7 +8,77 @@ export class PrismaClient {
   }
 }
 export namespace Prisma {
+  export interface MarketRole {
+    code: string;
+    description: string;
+  }
+
+  export interface MarketParticipant {
+    id: string;
+    name: string;
+    poolMemberId: string | null;
+  }
+
+  export interface MarketParticipantRole {
+    marketParticipantId: string;
+    roleCode: string;
+    effectiveFrom: Date;
+    effectiveTo: Date | null;
+    address1: string | null;
+    address2: string | null;
+    address3: string | null;
+    address4: string | null;
+    address5: string | null;
+    address6: string | null;
+    address7: string | null;
+    address8: string | null;
+    address9: string | null;
+    postCode: string | null;
+    distributorShortCode: string | null;
+  }
+
+  export interface ValidMtcLlfcCombination {
+    meterTimeswitchClassId: string;
+    meterTimeswitchClassEffectiveFrom: Date;
+    marketParticipantId: string;
+    marketParticipantEffectiveFrom: Date;
+    lineLossFactorClassId: string;
+    lineLossFactorClassEffectiveFrom: Date;
+    effectiveTo: Date | null;
+  }
+
+  export interface ValidMtcLlfcSscPcCombination {
+    meterTimeswitchClassId: string;
+    meterTimeswitchClassEffectiveFrom: Date;
+    marketParticipantId: string;
+    marketParticipantEffectiveFrom: Date;
+    standardSettlementConfigurationId: string;
+    standardSettlementConfigurationEffectiveFrom: Date;
+    lineLossFactorClassId: string;
+    lineLossFactorClassEffectiveFrom: Date;
+    profileClassId: number;
+    profileClassEffectiveFrom: Date;
+    effectiveTo: Date | null;
+    preservedTariffIndicator: string;
+  }
+
+  export interface Delegate<T> {
+    createMany(args: { data: T[]; skipDuplicates?: boolean }): Promise<void>;
+  }
+
   export class TransactionClient {
-    [key: string]: any;
+    marketRole: Delegate<MarketRole> = { createMany: async () => {} };
+    marketParticipant: Delegate<MarketParticipant> = {
+      createMany: async () => {},
+    };
+    marketParticipantRole: Delegate<MarketParticipantRole> = {
+      createMany: async () => {},
+    };
+    validMtcLlfcCombination: Delegate<ValidMtcLlfcCombination> = {
+      createMany: async () => {},
+    };
+    validMtcLlfcSscPcCombination: Delegate<ValidMtcLlfcSscPcCombination> = {
+      createMany: async () => {},
+    };
   }
 }

--- a/packages/engine/src/lib/mdd-loader.ts
+++ b/packages/engine/src/lib/mdd-loader.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { parse } from 'date-fns';
 import { parse as parseCsv } from 'csv-parse/sync';
-import { Prisma } from '../../generated/prisma';
+import type { Prisma } from '../../generated/prisma';
 
 /**
  * Read a CSV file and return rows.
@@ -50,7 +50,7 @@ export async function seedMarketRoles(
 ): Promise<void> {
   const rows = await readCsv(path.join(dir, 'Market_Role.csv'));
   rows.shift();
-  await tx['marketRole'].createMany({
+  await tx.marketRole.createMany({
     data: rows.map(([code, description]) => ({ code, description })),
     skipDuplicates: true,
   });
@@ -65,7 +65,7 @@ export async function seedMarketParticipants(
 ): Promise<void> {
   const rows = await readCsv(path.join(dir, 'Market_Participant.csv'));
   rows.shift();
-  await tx['marketParticipant'].createMany({
+  await tx.marketParticipant.createMany({
     data: rows.map(([id, name, poolMemberId]) => ({
       id,
       name,
@@ -84,7 +84,7 @@ export async function seedMarketParticipantRoles(
 ): Promise<void> {
   const rows = await readCsv(path.join(dir, 'Market_Participant_Role.csv'));
   rows.shift();
-  await tx['marketParticipantRole'].createMany({
+  await tx.marketParticipantRole.createMany({
     data: rows.map((r) => ({
       marketParticipantId: r[0],
       roleCode: r[1],
@@ -115,7 +115,7 @@ export async function seedValidMtcLlfcCombinations(
 ): Promise<void> {
   const rows = await readCsv(path.join(dir, 'Valid_MTC_LLFC_Combination.csv'));
   rows.shift();
-  await tx['validMtcLlfcCombination'].createMany({
+  await tx.validMtcLlfcCombination.createMany({
     data: rows.map((r) => ({
       meterTimeswitchClassId: r[0],
       meterTimeswitchClassEffectiveFrom: parseDate(r[1])!,
@@ -140,7 +140,7 @@ export async function seedValidMtcLlfcSscPcCombinations(
     path.join(dir, 'Valid_MTC_LLFC_SSC_PC_Combination.csv')
   );
   rows.shift();
-  await tx['validMtcLlfcSscPcCombination'].createMany({
+  await tx.validMtcLlfcSscPcCombination.createMany({
     data: rows.map((r) => ({
       meterTimeswitchClassId: r[0],
       meterTimeswitchClassEffectiveFrom: parseDate(r[1])!,


### PR DESCRIPTION
## Why
Improve type safety for seed logic by exposing typed Prisma model delegates.

## Summary
- define MarketRole and other interfaces in generated Prisma client stub
- type TransactionClient properties to use these interfaces
- update mdd-loader to use typed delegates

## Testing
- `yarn lint --fix`
- `yarn format`
- `yarn ts:check`
- `yarn nx run-many --target=test`


------
https://chatgpt.com/codex/tasks/task_e_68527a8273ac8326b64c95c98ad0e366

## Summary by Sourcery

Expose typed Prisma transaction client delegates and update seed loader to use them for improved type safety

New Features:
- Generate typed model interfaces (e.g., MarketRole) in the Prisma client stub
- Expose typed properties for each model on the Prisma TransactionClient

Enhancements:
- Refactor mdd-loader seed scripts to use dot-notation for typed transaction delegates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved code readability by updating import statements and changing syntax for accessing database model delegates. No changes to application behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->