### PR TITLE
feat(prisma): update tsconfig

### DIFF
--- a/prisma/tsconfig.lib.json
+++ b/prisma/tsconfig.lib.json
@@ -3,8 +3,9 @@
   "compilerOptions": {
     "outDir": "../dist/prisma",
     "declaration": true,
-    "types": ["node"]
+    "types": ["node"],
+    "rootDir": ".."
   },
   "include": ["*.ts"],
-  "exclude": ["*.spec.ts"]
+  "exclude": ["*.spec.ts", "vitest.config.ts"]
 }


### PR DESCRIPTION
## Why
- ensure ts compiler roots correctly and skip vitest config

## Summary
- set `rootDir` in prisma tsconfig
- ignore `vitest.config.ts`

## Testing
- `yarn lint --fix prisma/tsconfig.lib.json` *(fails)*
- `yarn lint --fix`
- `yarn ts:check prisma` *(fails)*
- `yarn ts:check`
- `yarn nx run prisma:build` *(fails)*

------
https://chatgpt.com/codex/tasks/task_e_685295e1369c8326a41c566df45cf90b