### PR TITLE
feat(prisma): specify build rootDir

### DIFF
--- a/prisma/project.json
+++ b/prisma/project.json
@@ -10,7 +10,8 @@
       "options": {
         "outputPath": "dist/prisma",
         "main": "prisma/seed.ts",
-        "tsConfig": "prisma/tsconfig.lib.json"
+        "tsConfig": "prisma/tsconfig.lib.json",
+        "rootDir": "."
       }
     }
   }

--- a/prisma/tsconfig.lib.json
+++ b/prisma/tsconfig.lib.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "outDir": "../dist/prisma",
     "declaration": true,
-    "types": ["node"],
-    "rootDir": ".."
+    "types": ["node"]
   },
   "include": ["*.ts"],
   "exclude": ["*.spec.ts", "vitest.config.ts"]


### PR DESCRIPTION
## Why
Ensure Prisma build uses repository root for TypeScript compilation and remove redundant configuration.

## Changes
- add `rootDir` option in `prisma/project.json`
- drop `rootDir` from `prisma/tsconfig.lib.json`


------
https://chatgpt.com/codex/tasks/task_e_6852eaf244ec832681a7ea09d8a00c2f

## Summary by Sourcery

Configure Prisma build to use repository root for TypeScript compilation and remove redundant rootDir setting

Build:
- Add rootDir option to prisma/project.json build configuration
- Remove rootDir from prisma/tsconfig.lib.json