### PR TITLE
feat(docs): document prisma lint command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,37 +1,44 @@
 ## Code Style
-- Lint and fix before every commit: `yarn lint --fix`.
+
+- Lint and fix before every commit: `yarn lint --fix`. Use `yarn nx run prisma:lint` for the Prisma package.
 - Format code via `yarn format` (Prettier).
 - Type-check with `yarn ts:check`.
 
 ## Monorepo Commands
-| Task        | Command               |
-|-------------|-----------------------|
-| Dev server  | `yarn nx run web:dev` |
+
+| Task        | Command                          |
+| ----------- | -------------------------------- |
+| Dev server  | `yarn nx run web:dev`            |
 | Unit tests  | `yarn nx run-many --target=test` |
-| E2E tests   | `yarn e2e`            |
-| Build image | `docker build .`      |
+| E2E tests   | `yarn e2e`                       |
+| Build image | `docker build .`                 |
 
 Codex **must** call these rather than raw `npm` equivalents.
 
 ## Architectural Guard-rails
+
 - Use **Next.js 15 App Router** for all new routes (avoid `/pages`).
 - All shared business logic lives in `packages/engine`.
 - Fetch MDD data only via the read-only Prisma client; no ad-hoc file reads.
 
 ## Testing & Coverage
+
 - Unit tests in `*.spec.ts`; strive for ≥ 90 % line coverage.
 - E2E tests (Playwright) reside in `/tests/e2e` and must run headless.
 
 ## Pull-request Conventions
+
 - Title pattern: `feat(scope): summary`.
 - Include a **“Why”** section explaining the value.
 - Add the label `release:patch|minor|major` to trigger semantic-release.
 
 ## Security
+
 - Disallow `eval`, `Function`, or dynamic `import()` from untrusted input.
 - Sanitise any string that hits a shell or SQL query.
 
 ## Release Checklist
+
 1. `yarn nx affected --target=test,lint,build`
 2. `docker run --rm <image> yarn prisma validate`
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ consistent.
 
 ## Contributing
 
-Run `yarn lint --fix`, `yarn format` and `yarn ts:check` before committing.
+Run `yarn lint --fix` and `yarn format` from the repo root (or `yarn nx run prisma:lint` for the Prisma package), then `yarn ts:check` before committing.
 Execute `yarn nx run-many --target=test` and `yarn test` to verify behaviour.
 Use the PR title pattern `feat(scope): summary` and label your PR with
 `release:patch`, `release:minor` or `release:major`.


### PR DESCRIPTION
## Why
Clarifies how to lint Prisma code from the repository root.

## Summary
- mention `yarn nx run prisma:lint` in AGENTS and README

## Testing
- `yarn lint --fix`
- `yarn format`
- `yarn ts:check`
- `yarn nx run-many --target=test`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_6853019d52a88326a94e6dd8890e58e1

## Summary by Sourcery

Documentation:
- Add instructions for using `yarn nx run prisma:lint` for the Prisma package in AGENTS.md and README.md.