### PR TITLE
feat(mdd-loader): use execFileSync in loader tests

### DIFF
--- a/apps/mdd-loader-e2e/src/mdd-loader/mdd-loader.spec.ts
+++ b/apps/mdd-loader-e2e/src/mdd-loader/mdd-loader.spec.ts
@@ -1,11 +1,11 @@
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { join } from 'path';
 
 describe('CLI tests', () => {
   it('runs the seed script', () => {
     const cliPath = join(process.cwd(), 'dist/apps/mdd-loader');
 
-    const output = execSync(`node ${cliPath}`).toString();
+    const output = execFileSync('node', [cliPath]).toString();
 
     expect(output).toMatch(/✅ Seed completed from/);
   });

--- a/apps/mdd-loader/src/seed.spec.ts
+++ b/apps/mdd-loader/src/seed.spec.ts
@@ -27,7 +27,7 @@ describe('main', () => {
   });
 
   it('uses default data directory', async () => {
-    await main();
+    await main([]);
 
     expect(seed).toHaveBeenCalledWith(path.resolve('data'));
   });


### PR DESCRIPTION
## Why
ExecFileSync avoids shell parsing issues when invoking Node for the e2e loader test and stabilizes test runs.

## Notes
- ran `yarn lint --fix`, `yarn nx run prisma:lint`, `yarn format`, `yarn ts:check`, and `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_685400761cc08326bdb2717a511dbda3

## Summary by Sourcery

Switch loader tests to use execFileSync for Node invocations, improving stability and avoiding shell parsing issues

Enhancements:
- Switch to execFileSync for running the loader CLI in e2e tests to avoid shell parsing issues
- Pass an empty arguments array to `main` in the seed unit test to ensure consistent default behavior

Tests:
- Stabilize loader tests by leveraging synchronous process execution

Chores:
- Apply lint fixes, code formatting, and TypeScript checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved reliability of test cases for CLI and data directory handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->