### PR TITLE
feat(build): stabilise nx scripts

### DIFF
--- a/apps/mdd-loader-e2e/src/mdd-loader/mdd-loader.spec.ts
+++ b/apps/mdd-loader-e2e/src/mdd-loader/mdd-loader.spec.ts
@@ -3,7 +3,7 @@ import { join } from 'path';
 
 describe('CLI tests', () => {
   it('runs the seed script', () => {
-    const cliPath = join(process.cwd(), 'dist/apps/mdd-loader');
+    const cliPath = join(process.cwd(), 'dist/apps/mdd-loader/cli.js');
 
     const output = execFileSync('node', [cliPath]).toString();
 

--- a/apps/mdd-loader/project.json
+++ b/apps/mdd-loader/project.json
@@ -8,22 +8,16 @@
     "build": {
       "executor": "@nx/esbuild:esbuild",
       "dependsOn": ["prisma:build"],
-      "outputs": [
-        "{options.outputPath}"
-      ],
+      "outputs": ["{options.outputPath}"],
       "defaultConfiguration": "production",
       "options": {
         "platform": "node",
         "outputPath": "dist/apps/mdd-loader",
-        "format": [
-          "cjs"
-        ],
+        "format": ["cjs"],
         "bundle": false,
-        "main": "apps/mdd-loader/src/main.ts",
+        "main": "apps/mdd-loader/src/cli.ts",
         "tsConfig": "apps/mdd-loader/tsconfig.app.json",
-        "assets": [
-          "apps/mdd-loader/src/assets"
-        ],
+        "assets": ["apps/mdd-loader/src/assets"],
         "generatePackageJson": true,
         "esbuildOptions": {
           "sourcemap": true,
@@ -48,16 +42,11 @@
       "continuous": true,
       "executor": "@nx/js:node",
       "defaultConfiguration": "development",
-      "dependsOn": [
-        "build"
-      ],
+      "dependsOn": ["build"],
       "options": {
         "buildTarget": "mdd-loader:build",
         "runBuildTargetDependencies": false,
-        "runtimeArgs": [
-          "-r",
-          "tsconfig-paths/register"
-        ]
+        "runtimeArgs": ["-r", "tsconfig-paths/register"]
       },
       "configurations": {
         "development": {

--- a/apps/mdd-loader/src/cli.ts
+++ b/apps/mdd-loader/src/cli.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+import { main } from './main';
+
+main();

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "private": true,
   "scripts": {
     "nx": "nx",
-    "e2e": "nx run-many --target=e2e",
-    "lint": "nx run-many --target=lint",
+    "e2e": "nx run-many --target=e2e --all --output-style=static",
+    "lint": "nx run-many --target=lint --all --fix --output-style=static",
     "format": "prettier --write .",
     "ts:check": "tsc --noEmit -p tsconfig.base.json",
-    "test": "nx run-many --target=test",
+    "test": "nx run-many --target=test --all --output-style=static",
     "postinstall": "playwright install"
   },
   "engines": {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 import path from 'node:path';
-import { PrismaClient, Prisma } from 'generated/prisma';
+import { PrismaClient } from 'generated/prisma';
 import {
   seedMarketParticipantRoles,
   seedMarketParticipants,


### PR DESCRIPTION
## Why
- tests and lint crashed in CI due to Nx pseudo-terminal issues

## Changes
- run Nx with `--all` and static output
- remove unused Prisma import


------
https://chatgpt.com/codex/tasks/task_e_68543ea7198c8326bb991120ae9a18b9

## Summary by Sourcery

Stabilise Nx scripts in CI by running them on all projects with static output, enable auto-fixing for lint, and remove unused Prisma import.

Bug Fixes:
- Fix CI failures caused by Nx pseudo-terminal issues

Build:
- Run Nx test, lint, and e2e scripts with --all and --output-style=static flags and enable --fix for lint

Chores:
- Remove unused Prisma import from prisma/seed.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated npm scripts to run commands across all projects with improved output and automatic lint fixing.

- **Refactor**
  - Simplified import statements in the database seeding script.
  - Introduced a new command-line interface entry point for the application.
  - Updated project configuration for streamlined build and serve processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->