### PR TITLE
docs(readme): fix mdd-loader serve command

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The loader ingests the monthly CSV drop located in `data/`.
 Ensure the database connection variables are set before running:
 
 ```bash
-yarn nx serve mdd-loader -- --dir=./data
+yarn nx serve mdd-loader --args=--dir=./data
 ```
 
 It runs via the project's read-only Prisma client.


### PR DESCRIPTION
## Why

`yarn nx serve mdd-loader -- --dir=./data` fails because `dir` is not a target option. Passing the argument through `--args` resolves the issue.

## What

- update README with correct command

------
https://chatgpt.com/codex/tasks/task_e_685495a9861c8326b155f128dd8a58fc

## Summary by Sourcery

Documentation:
- Correct the yarn nx serve mdd-loader command to use --args=--dir=./data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the command syntax in the README for running the MDD loader to use the `--args` option for specifying the directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->