### PR TITLE
feat(engine): add domain models

### DIFF
--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -1,2 +1,3 @@
 export * from './lib/engine';
 export * from './lib/mdd-loader';
+export * from './lib/models';

--- a/packages/engine/src/lib/models/gsp-group.spec.ts
+++ b/packages/engine/src/lib/models/gsp-group.spec.ts
@@ -1,0 +1,7 @@
+import { isGspGroup } from './gsp-group';
+
+describe('isGspGroup', () => {
+  it('validates a GSP group', () => {
+    expect(isGspGroup({ id: 'A', name: 'Group' })).toBe(true);
+  });
+});

--- a/packages/engine/src/lib/models/gsp-group.spec.ts
+++ b/packages/engine/src/lib/models/gsp-group.spec.ts
@@ -2,6 +2,6 @@ import { isGspGroup } from './gsp-group';
 
 describe('isGspGroup', () => {
   it('validates a GSP group', () => {
-    expect(isGspGroup({ id: 'A', name: 'Group' })).toBe(true);
+    expect(isGspGroup({ id: '_A', name: 'Eastern' })).toBe(true);
   });
 });

--- a/packages/engine/src/lib/models/gsp-group.ts
+++ b/packages/engine/src/lib/models/gsp-group.ts
@@ -1,0 +1,21 @@
+'use strict';
+
+/**
+ * Group of Grid Supply Points.
+ */
+export interface GspGroup {
+  id: string;
+  name: string;
+}
+
+/**
+ * Check if a value is a {@link GspGroup}.
+ *
+ * @param value - Unknown value.
+ * @returns `true` when valid.
+ */
+export function isGspGroup(value: unknown): value is GspGroup {
+  if (!value || typeof value !== 'object') return false;
+  const r = value as Record<string, unknown>;
+  return typeof r['id'] === 'string' && typeof r['name'] === 'string';
+}

--- a/packages/engine/src/lib/models/index.ts
+++ b/packages/engine/src/lib/models/index.ts
@@ -1,0 +1,7 @@
+export * from './gsp-group';
+export * from './market-participant';
+export * from './market-participant-role';
+export * from './market-role';
+export * from './profile-class';
+export * from './valid-mtc-llfc-combination';
+export * from './valid-mtc-llfc-ssc-pc-combination';

--- a/packages/engine/src/lib/models/market-participant-role.spec.ts
+++ b/packages/engine/src/lib/models/market-participant-role.spec.ts
@@ -3,13 +3,13 @@ import type { MarketRole } from './market-role';
 
 describe('isMarketParticipantRole', () => {
   it('validates a role assignment', () => {
-    const role: MarketRole = { code: 'A', description: 'Role' };
+    const role: MarketRole = { code: 'A', description: 'HH Data Aggregator' };
     expect(
       isMarketParticipantRole({
-        marketParticipantId: 'P1',
+        marketParticipantId: 'PADD',
         roleCode: 'A',
         marketRole: role,
-        effectiveFrom: new Date(),
+        effectiveFrom: new Date('2024-03-20'),
         effectiveTo: null,
       })
     ).toBe(true);

--- a/packages/engine/src/lib/models/market-participant-role.spec.ts
+++ b/packages/engine/src/lib/models/market-participant-role.spec.ts
@@ -1,0 +1,17 @@
+import { isMarketParticipantRole } from './market-participant-role';
+import type { MarketRole } from './market-role';
+
+describe('isMarketParticipantRole', () => {
+  it('validates a role assignment', () => {
+    const role: MarketRole = { code: 'A', description: 'Role' };
+    expect(
+      isMarketParticipantRole({
+        marketParticipantId: 'P1',
+        roleCode: 'A',
+        marketRole: role,
+        effectiveFrom: new Date(),
+        effectiveTo: null,
+      })
+    ).toBe(true);
+  });
+});

--- a/packages/engine/src/lib/models/market-participant-role.ts
+++ b/packages/engine/src/lib/models/market-participant-role.ts
@@ -1,0 +1,34 @@
+'use strict';
+
+import type { MarketRole } from './market-role';
+
+/**
+ * Role assignment for a market participant.
+ */
+export interface MarketParticipantRole {
+  marketParticipantId: string;
+  roleCode: string;
+  marketRole: MarketRole;
+  effectiveFrom: Date;
+  effectiveTo: Date | null;
+}
+
+/**
+ * Runtime check for {@link MarketParticipantRole}.
+ *
+ * @param value - Unknown value.
+ * @returns `true` if the shape matches.
+ */
+export function isMarketParticipantRole(
+  value: unknown
+): value is MarketParticipantRole {
+  if (!value || typeof value !== 'object') return false;
+  const r = value as Record<string, unknown>;
+  return (
+    typeof r['marketParticipantId'] === 'string' &&
+    typeof r['roleCode'] === 'string' &&
+    r['marketRole'] !== undefined &&
+    r['effectiveFrom'] instanceof Date &&
+    (r['effectiveTo'] instanceof Date || r['effectiveTo'] === null)
+  );
+}

--- a/packages/engine/src/lib/models/market-participant.spec.ts
+++ b/packages/engine/src/lib/models/market-participant.spec.ts
@@ -1,0 +1,9 @@
+import { isMarketParticipant } from './market-participant';
+
+describe('isMarketParticipant', () => {
+  it('validates a participant', () => {
+    expect(
+      isMarketParticipant({ id: 'P1', name: 'Foo', poolMemberId: null })
+    ).toBe(true);
+  });
+});

--- a/packages/engine/src/lib/models/market-participant.spec.ts
+++ b/packages/engine/src/lib/models/market-participant.spec.ts
@@ -3,7 +3,11 @@ import { isMarketParticipant } from './market-participant';
 describe('isMarketParticipant', () => {
   it('validates a participant', () => {
     expect(
-      isMarketParticipant({ id: 'P1', name: 'Foo', poolMemberId: null })
+      isMarketParticipant({
+        id: 'PADD',
+        name: 'Fuse Energy Supply Limited',
+        poolMemberId: 'PADD',
+      })
     ).toBe(true);
   });
 });

--- a/packages/engine/src/lib/models/market-participant.ts
+++ b/packages/engine/src/lib/models/market-participant.ts
@@ -1,0 +1,28 @@
+'use strict';
+
+/**
+ * An organisation participating in the energy market.
+ */
+export interface MarketParticipant {
+  id: string;
+  name: string;
+  poolMemberId: string | null;
+}
+
+/**
+ * Determine whether a value is a {@link MarketParticipant}.
+ *
+ * @param value - Unknown value to check.
+ * @returns `true` if the value matches the interface.
+ */
+export function isMarketParticipant(
+  value: unknown
+): value is MarketParticipant {
+  if (!value || typeof value !== 'object') return false;
+  const r = value as Record<string, unknown>;
+  return (
+    typeof r['id'] === 'string' &&
+    typeof r['name'] === 'string' &&
+    (typeof r['poolMemberId'] === 'string' || r['poolMemberId'] === null)
+  );
+}

--- a/packages/engine/src/lib/models/market-role.spec.ts
+++ b/packages/engine/src/lib/models/market-role.spec.ts
@@ -1,0 +1,7 @@
+import { isMarketRole } from './market-role';
+
+describe('isMarketRole', () => {
+  it('validates a market role', () => {
+    expect(isMarketRole({ code: 'A', description: 'Role' })).toBe(true);
+  });
+});

--- a/packages/engine/src/lib/models/market-role.spec.ts
+++ b/packages/engine/src/lib/models/market-role.spec.ts
@@ -2,6 +2,8 @@ import { isMarketRole } from './market-role';
 
 describe('isMarketRole', () => {
   it('validates a market role', () => {
-    expect(isMarketRole({ code: 'A', description: 'Role' })).toBe(true);
+    expect(isMarketRole({ code: 'A', description: 'HH Data Aggregator' })).toBe(
+      true
+    );
   });
 });

--- a/packages/engine/src/lib/models/market-role.ts
+++ b/packages/engine/src/lib/models/market-role.ts
@@ -1,0 +1,21 @@
+'use strict';
+
+/**
+ * Market role such as Supplier or Distributor.
+ */
+export interface MarketRole {
+  code: string;
+  description: string;
+}
+
+/**
+ * Check if a value is a {@link MarketRole}.
+ *
+ * @param value - Unknown value to validate.
+ * @returns `true` when the value conforms to {@link MarketRole}.
+ */
+export function isMarketRole(value: unknown): value is MarketRole {
+  if (!value || typeof value !== 'object') return false;
+  const r = value as Record<string, unknown>;
+  return typeof r['code'] === 'string' && typeof r['description'] === 'string';
+}

--- a/packages/engine/src/lib/models/profile-class.spec.ts
+++ b/packages/engine/src/lib/models/profile-class.spec.ts
@@ -1,0 +1,15 @@
+import { isProfileClass } from './profile-class';
+
+describe('isProfileClass', () => {
+  it('validates a profile class', () => {
+    expect(
+      isProfileClass({
+        id: 1,
+        effectiveFromSettlementDate: new Date(),
+        description: 'desc',
+        switchedLoadProfileClassInd: false,
+        effectiveToSettlementDate: null,
+      })
+    ).toBe(true);
+  });
+});

--- a/packages/engine/src/lib/models/profile-class.spec.ts
+++ b/packages/engine/src/lib/models/profile-class.spec.ts
@@ -5,8 +5,8 @@ describe('isProfileClass', () => {
     expect(
       isProfileClass({
         id: 1,
-        effectiveFromSettlementDate: new Date(),
-        description: 'desc',
+        effectiveFromSettlementDate: new Date('1996-04-01'),
+        description: 'Domestic Unrestricted',
         switchedLoadProfileClassInd: false,
         effectiveToSettlementDate: null,
       })

--- a/packages/engine/src/lib/models/profile-class.ts
+++ b/packages/engine/src/lib/models/profile-class.ts
@@ -1,0 +1,31 @@
+'use strict';
+
+/**
+ * Profile class used for settlement.
+ */
+export interface ProfileClass {
+  id: number;
+  effectiveFromSettlementDate: Date;
+  description: string;
+  switchedLoadProfileClassInd: boolean;
+  effectiveToSettlementDate: Date | null;
+}
+
+/**
+ * Check if a value is a {@link ProfileClass}.
+ *
+ * @param value - Value to examine.
+ * @returns `true` when shape matches.
+ */
+export function isProfileClass(value: unknown): value is ProfileClass {
+  if (!value || typeof value !== 'object') return false;
+  const r = value as Record<string, unknown>;
+  return (
+    typeof r['id'] === 'number' &&
+    r['effectiveFromSettlementDate'] instanceof Date &&
+    typeof r['description'] === 'string' &&
+    typeof r['switchedLoadProfileClassInd'] === 'boolean' &&
+    (r['effectiveToSettlementDate'] instanceof Date ||
+      r['effectiveToSettlementDate'] === null)
+  );
+}

--- a/packages/engine/src/lib/models/valid-mtc-llfc-combination.spec.ts
+++ b/packages/engine/src/lib/models/valid-mtc-llfc-combination.spec.ts
@@ -1,0 +1,17 @@
+import { isValidMtcLlfcCombination } from './valid-mtc-llfc-combination';
+
+describe('isValidMtcLlfcCombination', () => {
+  it('validates a combination', () => {
+    expect(
+      isValidMtcLlfcCombination({
+        meterTimeswitchClassId: 'A',
+        meterTimeswitchClassEffectiveFrom: new Date(),
+        marketParticipantId: 'P',
+        marketParticipantEffectiveFrom: new Date(),
+        lineLossFactorClassId: 'L',
+        lineLossFactorClassEffectiveFrom: new Date(),
+        effectiveTo: null,
+      })
+    ).toBe(true);
+  });
+});

--- a/packages/engine/src/lib/models/valid-mtc-llfc-combination.spec.ts
+++ b/packages/engine/src/lib/models/valid-mtc-llfc-combination.spec.ts
@@ -4,13 +4,13 @@ describe('isValidMtcLlfcCombination', () => {
   it('validates a combination', () => {
     expect(
       isValidMtcLlfcCombination({
-        meterTimeswitchClassId: 'A',
-        meterTimeswitchClassEffectiveFrom: new Date(),
-        marketParticipantId: 'P',
-        marketParticipantEffectiveFrom: new Date(),
-        lineLossFactorClassId: 'L',
-        lineLossFactorClassEffectiveFrom: new Date(),
-        effectiveTo: null,
+        meterTimeswitchClassId: '70',
+        meterTimeswitchClassEffectiveFrom: new Date('1996-04-01'),
+        marketParticipantId: 'SOUT',
+        marketParticipantEffectiveFrom: new Date('1996-04-01'),
+        lineLossFactorClassId: '453',
+        lineLossFactorClassEffectiveFrom: new Date('1996-04-01'),
+        effectiveTo: new Date('2022-03-31'),
       })
     ).toBe(true);
   });

--- a/packages/engine/src/lib/models/valid-mtc-llfc-combination.ts
+++ b/packages/engine/src/lib/models/valid-mtc-llfc-combination.ts
@@ -1,0 +1,36 @@
+'use strict';
+
+/**
+ * Valid meter timeswitch class and line loss factor class combination.
+ */
+export interface ValidMtcLlfcCombination {
+  meterTimeswitchClassId: string;
+  meterTimeswitchClassEffectiveFrom: Date;
+  marketParticipantId: string;
+  marketParticipantEffectiveFrom: Date;
+  lineLossFactorClassId: string;
+  lineLossFactorClassEffectiveFrom: Date;
+  effectiveTo: Date | null;
+}
+
+/**
+ * Check if a value is a {@link ValidMtcLlfcCombination}.
+ *
+ * @param value - Value to validate.
+ * @returns `true` when valid.
+ */
+export function isValidMtcLlfcCombination(
+  value: unknown
+): value is ValidMtcLlfcCombination {
+  if (!value || typeof value !== 'object') return false;
+  const r = value as Record<string, unknown>;
+  return (
+    typeof r['meterTimeswitchClassId'] === 'string' &&
+    r['meterTimeswitchClassEffectiveFrom'] instanceof Date &&
+    typeof r['marketParticipantId'] === 'string' &&
+    r['marketParticipantEffectiveFrom'] instanceof Date &&
+    typeof r['lineLossFactorClassId'] === 'string' &&
+    r['lineLossFactorClassEffectiveFrom'] instanceof Date &&
+    (r['effectiveTo'] instanceof Date || r['effectiveTo'] === null)
+  );
+}

--- a/packages/engine/src/lib/models/valid-mtc-llfc-ssc-pc-combination.spec.ts
+++ b/packages/engine/src/lib/models/valid-mtc-llfc-ssc-pc-combination.spec.ts
@@ -4,18 +4,18 @@ describe('isValidMtcLlfcSscPcCombination', () => {
   it('validates a combination', () => {
     expect(
       isValidMtcLlfcSscPcCombination({
-        meterTimeswitchClassId: 'A',
-        meterTimeswitchClassEffectiveFrom: new Date(),
-        marketParticipantId: 'P',
-        marketParticipantEffectiveFrom: new Date(),
-        standardSettlementConfigurationId: 'S',
-        standardSettlementConfigurationEffectiveFrom: new Date(),
-        lineLossFactorClassId: 'L',
-        lineLossFactorClassEffectiveFrom: new Date(),
-        profileClassId: 1,
-        profileClassEffectiveFrom: new Date(),
-        effectiveTo: null,
-        preservedTariffIndicator: 'Y',
+        meterTimeswitchClassId: '1',
+        meterTimeswitchClassEffectiveFrom: new Date('1996-04-01'),
+        marketParticipantId: 'EDFI',
+        marketParticipantEffectiveFrom: new Date('2009-04-16'),
+        standardSettlementConfigurationId: '349',
+        standardSettlementConfigurationEffectiveFrom: new Date('2009-04-16'),
+        lineLossFactorClassId: '906',
+        lineLossFactorClassEffectiveFrom: new Date('2009-04-16'),
+        profileClassId: 2,
+        profileClassEffectiveFrom: new Date('2010-03-17'),
+        effectiveTo: new Date('2014-08-20'),
+        preservedTariffIndicator: false,
       })
     ).toBe(true);
   });

--- a/packages/engine/src/lib/models/valid-mtc-llfc-ssc-pc-combination.spec.ts
+++ b/packages/engine/src/lib/models/valid-mtc-llfc-ssc-pc-combination.spec.ts
@@ -1,0 +1,22 @@
+import { isValidMtcLlfcSscPcCombination } from './valid-mtc-llfc-ssc-pc-combination';
+
+describe('isValidMtcLlfcSscPcCombination', () => {
+  it('validates a combination', () => {
+    expect(
+      isValidMtcLlfcSscPcCombination({
+        meterTimeswitchClassId: 'A',
+        meterTimeswitchClassEffectiveFrom: new Date(),
+        marketParticipantId: 'P',
+        marketParticipantEffectiveFrom: new Date(),
+        standardSettlementConfigurationId: 'S',
+        standardSettlementConfigurationEffectiveFrom: new Date(),
+        lineLossFactorClassId: 'L',
+        lineLossFactorClassEffectiveFrom: new Date(),
+        profileClassId: 1,
+        profileClassEffectiveFrom: new Date(),
+        effectiveTo: null,
+        preservedTariffIndicator: 'Y',
+      })
+    ).toBe(true);
+  });
+});

--- a/packages/engine/src/lib/models/valid-mtc-llfc-ssc-pc-combination.ts
+++ b/packages/engine/src/lib/models/valid-mtc-llfc-ssc-pc-combination.ts
@@ -1,0 +1,46 @@
+'use strict';
+
+/**
+ * Valid MTC, LLFC, SSC and Profile Class combination.
+ */
+export interface ValidMtcLlfcSscPcCombination {
+  meterTimeswitchClassId: string;
+  meterTimeswitchClassEffectiveFrom: Date;
+  marketParticipantId: string;
+  marketParticipantEffectiveFrom: Date;
+  standardSettlementConfigurationId: string;
+  standardSettlementConfigurationEffectiveFrom: Date;
+  lineLossFactorClassId: string;
+  lineLossFactorClassEffectiveFrom: Date;
+  profileClassId: number;
+  profileClassEffectiveFrom: Date;
+  effectiveTo: Date | null;
+  preservedTariffIndicator: string;
+}
+
+/**
+ * Validate a {@link ValidMtcLlfcSscPcCombination} at runtime.
+ *
+ * @param value - Unknown value.
+ * @returns `true` when the value matches the interface.
+ */
+export function isValidMtcLlfcSscPcCombination(
+  value: unknown
+): value is ValidMtcLlfcSscPcCombination {
+  if (!value || typeof value !== 'object') return false;
+  const r = value as Record<string, unknown>;
+  return (
+    typeof r['meterTimeswitchClassId'] === 'string' &&
+    r['meterTimeswitchClassEffectiveFrom'] instanceof Date &&
+    typeof r['marketParticipantId'] === 'string' &&
+    r['marketParticipantEffectiveFrom'] instanceof Date &&
+    typeof r['standardSettlementConfigurationId'] === 'string' &&
+    r['standardSettlementConfigurationEffectiveFrom'] instanceof Date &&
+    typeof r['lineLossFactorClassId'] === 'string' &&
+    r['lineLossFactorClassEffectiveFrom'] instanceof Date &&
+    typeof r['profileClassId'] === 'number' &&
+    r['profileClassEffectiveFrom'] instanceof Date &&
+    (r['effectiveTo'] instanceof Date || r['effectiveTo'] === null) &&
+    typeof r['preservedTariffIndicator'] === 'string'
+  );
+}

--- a/packages/engine/src/lib/models/valid-mtc-llfc-ssc-pc-combination.ts
+++ b/packages/engine/src/lib/models/valid-mtc-llfc-ssc-pc-combination.ts
@@ -15,7 +15,7 @@ export interface ValidMtcLlfcSscPcCombination {
   profileClassId: number;
   profileClassEffectiveFrom: Date;
   effectiveTo: Date | null;
-  preservedTariffIndicator: string;
+  preservedTariffIndicator: boolean;
 }
 
 /**
@@ -41,6 +41,6 @@ export function isValidMtcLlfcSscPcCombination(
     typeof r['profileClassId'] === 'number' &&
     r['profileClassEffectiveFrom'] instanceof Date &&
     (r['effectiveTo'] instanceof Date || r['effectiveTo'] === null) &&
-    typeof r['preservedTariffIndicator'] === 'string'
+    typeof r['preservedTariffIndicator'] === 'boolean'
   );
 }


### PR DESCRIPTION
## Why
Provide typed representations of core MDD entities for use across the monorepo.

## Summary
- add market role, participant and related domain models with type guards
- export models via engine barrel
- test guards for valid objects

## Testing
- `yarn lint --fix`
- `yarn format`
- `yarn ts:check`
- `yarn nx run prisma:lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_685523fd4df8832687a03e1bf7d0e102

## Summary by Sourcery

Introduce typed domain models and runtime validators for core MDD entities and expose them via the engine package.

New Features:
- Define interfaces and type guard functions for MarketParticipant, MarketRole, GspGroup, ProfileClass, MarketParticipantRole, and valid MTC/LLFC(SSC/PC) combinations.

Enhancements:
- Export the new domain models through the engine package's public API barrel.

Tests:
- Add unit tests to verify the correctness of the newly introduced type guard functions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced several new data model interfaces and validation functions for market participants, roles, groups, profile classes, and valid combinations.
	- Expanded the public API to provide access to these new models from a central entry point.

- **Tests**
	- Added comprehensive tests for all new data model validation functions to ensure correct identification and validation of data structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->