### PR TITLE
feat(engine): add MDD data repository

### DIFF
--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -4,3 +4,4 @@ export * from './lib/models';
 export * from './lib/rules/types';
 export * from './lib/rules/gspGroupIdFormatRule';
 export * from './lib/validator';
+export * from './lib/data/mddRepo';

--- a/packages/engine/src/lib/data/mddRepo.spec.ts
+++ b/packages/engine/src/lib/data/mddRepo.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { PrismaClient } from '../../../generated/prisma';
+import { PrismaMddRepo } from './mddRepo';
+
+describe('PrismaMddRepo', () => {
+  it('caches GSP groups', async () => {
+    const prisma = {
+      gspGroup: {
+        findMany: vi.fn().mockResolvedValue([{ id: '_A', name: 'Eastern' }]),
+      },
+      marketRole: {
+        findMany: vi.fn().mockResolvedValue([]),
+      },
+    } as unknown as PrismaClient;
+    const repo = new PrismaMddRepo(prisma);
+    const first = await repo.listGspGroups();
+    const second = await repo.listGspGroups();
+    expect(first).toEqual([{ id: '_A', name: 'Eastern' }]);
+    expect(prisma.gspGroup.findMany).toHaveBeenCalledTimes(1);
+    expect(second).toBe(first);
+  });
+
+  it('caches market roles', async () => {
+    const prisma = {
+      gspGroup: {
+        findMany: vi.fn().mockResolvedValue([]),
+      },
+      marketRole: {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            code: 'X',
+            description: 'Role X',
+          },
+        ]),
+      },
+    } as unknown as PrismaClient;
+    const repo = new PrismaMddRepo(prisma);
+    const first = await repo.listMarketRoles();
+    const second = await repo.listMarketRoles();
+    expect(first).toEqual([{ code: 'X', description: 'Role X' }]);
+    expect(prisma.marketRole.findMany).toHaveBeenCalledTimes(1);
+    expect(second).toBe(first);
+  });
+});

--- a/packages/engine/src/lib/data/mddRepo.ts
+++ b/packages/engine/src/lib/data/mddRepo.ts
@@ -1,0 +1,60 @@
+'use strict';
+
+import { PrismaClient } from '../../../generated/prisma';
+import type { GspGroup, MarketRole } from '../models';
+
+interface PrismaMddClient {
+  gspGroup: {
+    findMany(args: { select: { id: true; name: true } }): Promise<GspGroup[]>;
+  };
+  marketRole: {
+    findMany(args: {
+      select: { code: true; description: true };
+    }): Promise<MarketRole[]>;
+  };
+}
+
+/**
+ * Read-only repository for Market Domain Data.
+ */
+export class PrismaMddRepo {
+  private readonly cache = new Map<string, unknown>();
+  constructor(
+    private readonly prisma: PrismaMddClient &
+      PrismaClient = new PrismaClient() as unknown as PrismaMddClient &
+      PrismaClient
+  ) {}
+
+  /**
+   * List all GSP groups.
+   *
+   * @returns Array of groups.
+   */
+  async listGspGroups(): Promise<GspGroup[]> {
+    if (!this.cache.has('gspGroups')) {
+      const groups = await this.prisma.gspGroup.findMany({
+        select: { id: true, name: true },
+      });
+      this.cache.set('gspGroups', groups);
+    }
+    return this.cache.get('gspGroups') as GspGroup[];
+  }
+
+  /**
+   * List all market roles.
+   *
+   * @returns Array of roles.
+   */
+  async listMarketRoles(): Promise<MarketRole[]> {
+    if (!this.cache.has('marketRoles')) {
+      const roles = await this.prisma.marketRole.findMany({
+        select: { code: true, description: true },
+      });
+      this.cache.set('marketRoles', roles);
+    }
+    return this.cache.get('marketRoles') as MarketRole[];
+  }
+}
+
+/** Default repository instance. */
+export const mddRepo = new PrismaMddRepo();


### PR DESCRIPTION
## Why
- centralise access to Market Domain Data via Prisma

## Notes
- lint warnings remain
- tests use cached outputs



------
https://chatgpt.com/codex/tasks/task_e_68555ffcab3c8326a9e93562ab71f07c

## Summary by Sourcery

Centralize access to Market Domain Data by adding a Prisma-backed repository with caching and corresponding tests

New Features:
- Introduce a Prisma-backed read-only repository (PrismaMddRepo) for Market Domain Data

Enhancements:
- Cache GSP groups and market roles to prevent repeated database queries
- Export the MDD repository from the engine package entry point

Tests:
- Add unit tests for the MDD repository methods