### PR TITLE
feat(engine): add validator aggregator

### DIFF
--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -4,4 +4,5 @@ export * from './lib/models';
 export * from './lib/rules/types';
 export * from './lib/rules/gspGroupIdFormatRule';
 export * from './lib/validator';
+export * from './lib/validatorAggregator';
 export * from './lib/data/mddRepo';

--- a/packages/engine/src/lib/validatorAggregator.spec.ts
+++ b/packages/engine/src/lib/validatorAggregator.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { gspGroupIdFormatRule } from './rules/gspGroupIdFormatRule';
+import type { GspGroup } from './models/gsp-group';
+import { aggregateValidators } from './validatorAggregator';
+
+const groups: GspGroup[] = [
+  { id: '_A', name: 'Eastern' },
+  { id: 'AA', name: 'Invalid' },
+];
+
+describe('aggregateValidators', () => {
+  it('aggregates rule results per input', () => {
+    const results = aggregateValidators(groups, [gspGroupIdFormatRule]);
+
+    expect(results).toEqual([
+      { input: groups[0], errors: [] },
+      {
+        input: groups[1],
+        errors: [
+          {
+            code: 'INVALID_GSP_GROUP_ID_FORMAT',
+            message: 'GSP group id must match pattern "_A".',
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/packages/engine/src/lib/validatorAggregator.ts
+++ b/packages/engine/src/lib/validatorAggregator.ts
@@ -1,0 +1,25 @@
+'use strict';
+
+import type { Rule, ValidationError } from './rules/types';
+
+export interface AggregatedResult<T> {
+  input: T;
+  errors: ValidationError[];
+}
+
+/**
+ * Run validation rules against multiple inputs and aggregate errors.
+ *
+ * @param inputs - Items to validate.
+ * @param rules - Validation rules to execute.
+ * @returns Array of results per input.
+ */
+export function aggregateValidators<T>(
+  inputs: T[],
+  rules: Rule<T>[]
+): AggregatedResult<T>[] {
+  return inputs.map((input) => ({
+    input,
+    errors: rules.flatMap((rule) => rule.validate(input)),
+  }));
+}


### PR DESCRIPTION
## Why
Adds a utility to batch run validation rules and gather their errors.

## Testing
- `yarn lint --fix`
- `yarn ts:check`
- `yarn nx run prisma:lint`
- `yarn nx run-many --target=test --all --output-style=static`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_685565e0e1388326b7923cc10c00f0d6

## Summary by Sourcery

Introduce a validator aggregator to simplify running multiple validation rules against collections of inputs and aggregating their validation errors

New Features:
- Add aggregateValidators utility to batch-run validation rules and gather their errors
- Export validatorAggregator from the engine package

Tests:
- Add unit tests for aggregateValidators to verify error aggregation per input

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new validation aggregation utility that processes multiple inputs against a set of rules and returns detailed validation results.
- **Tests**
	- Added test coverage for the new validation aggregation functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->