### PR TITLE
feat(engine): add validator aggregator

### DIFF
--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -4,4 +4,5 @@ export * from './lib/models';
 export * from './lib/rules/types';
 export * from './lib/rules/gspGroupIdFormatRule';
 export * from './lib/validator';
+export * from './lib/aggregator';
 export * from './lib/data/mddRepo';

--- a/packages/engine/src/lib/aggregator.spec.ts
+++ b/packages/engine/src/lib/aggregator.spec.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { validateGspGroups } from './aggregator';
+
+describe('validateGspGroups', () => {
+  it('aggregates results for valid groups', () => {
+    const results = validateGspGroups([{ id: '_A', name: 'Eastern' }]);
+    expect(results).toEqual([{ id: '_A', errors: [] }]);
+  });
+
+  it('aggregates results with errors', () => {
+    const results = validateGspGroups([
+      { id: '_A', name: 'Eastern' },
+      { id: 'AA', name: 'Eastern' },
+    ]);
+    expect(results[1].errors).toEqual([
+      {
+        code: 'INVALID_GSP_GROUP_ID_FORMAT',
+        message: 'GSP group id must match pattern "_A".',
+      },
+    ]);
+  });
+});

--- a/packages/engine/src/lib/aggregator.ts
+++ b/packages/engine/src/lib/aggregator.ts
@@ -1,0 +1,25 @@
+'use strict';
+
+import type { GspGroup } from './models/gsp-group';
+import type { ValidationError } from './rules/types';
+import { validateGspGroup } from './validator';
+
+/**
+ * Validation result for a single GSP group.
+ */
+export interface AggregatedResult {
+  /** Group identifier */
+  id: string;
+  /** Errors associated with the group */
+  errors: ValidationError[];
+}
+
+/**
+ * Validate multiple GSP groups and aggregate their errors.
+ *
+ * @param groups - Array of groups to validate.
+ * @returns List of aggregated results.
+ */
+export function validateGspGroups(groups: GspGroup[]): AggregatedResult[] {
+  return groups.map((g) => ({ id: g.id, errors: validateGspGroup(g) }));
+}


### PR DESCRIPTION
## Why

Provide a helper to run all validation rules over multiple GSP groups.

## Summary
- add `validateGspGroups` aggregator
- test aggregation logic
- export aggregator from engine

## Testing
- `yarn lint --fix` *(fails: package not present in lockfile)*
- `yarn format` *(fails: package not present in lockfile)*
- `yarn ts:check` *(fails: package not present in lockfile)*
- `yarn test` *(fails: package not present in lockfile)*
- `npx nx run-many --target=lint --all --fix --output-style=static`
- `npx nx run-many --target=test --all --output-style=static`


------
https://chatgpt.com/codex/tasks/task_e_685565e0e1388326b7923cc10c00f0d6

## Summary by Sourcery

Add a helper function to aggregate validation results across multiple GSP groups and export it from the engine package

New Features:
- Introduce validateGspGroups function to run validation over arrays of GSP groups
- Export the new aggregator module from the engine entry point

Tests:
- Add unit tests for validateGspGroups to verify aggregated error output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced functionality to validate multiple GSP groups and aggregate their validation results.
- **Tests**
  - Added test coverage to ensure correct validation and error handling for GSP group validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->