### PR TITLE
feat(engine): combination generator

### DIFF
--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -6,3 +6,4 @@ export * from './lib/rules/gspGroupIdFormatRule';
 export * from './lib/validator';
 export * from './lib/aggregator';
 export * from './lib/data/mddRepo';
+export * from './lib/combination-generator';

--- a/packages/engine/src/lib/combination-generator.spec.ts
+++ b/packages/engine/src/lib/combination-generator.spec.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { generateCombinations } from './combination-generator';
+
+describe('generateCombinations', () => {
+  it('yields pair combinations', () => {
+    const combos = Array.from(
+      generateCombinations([
+        ['A', 'B'],
+        ['1', '2'],
+      ])
+    );
+    expect(combos).toEqual([
+      ['A', '1'],
+      ['A', '2'],
+      ['B', '1'],
+      ['B', '2'],
+    ]);
+  });
+
+  it('returns an empty array when no groups', () => {
+    const combos = Array.from(generateCombinations([]));
+    expect(combos).toEqual([]);
+  });
+});

--- a/packages/engine/src/lib/combination-generator.ts
+++ b/packages/engine/src/lib/combination-generator.ts
@@ -1,0 +1,21 @@
+'use strict';
+
+/**
+ * Generate the cartesian product of value groups.
+ *
+ * @param groups - Arrays of options for each position.
+ * @returns Generator producing every combination.
+ */
+export function* generateCombinations<T>(groups: T[][]): Generator<T[]> {
+  if (groups.length === 0) return;
+  function* walk(index: number, prefix: T[]): Generator<T[]> {
+    if (index === groups.length) {
+      yield prefix;
+      return;
+    }
+    for (const item of groups[index]) {
+      yield* walk(index + 1, [...prefix, item]);
+    }
+  }
+  yield* walk(0, []);
+}


### PR DESCRIPTION
## Why
- support generating cartesian products for UI inputs

## What
- add `generateCombinations` utility with tests
- re-export generator from engine


------
https://chatgpt.com/codex/tasks/task_e_6855c2c912088326826035e71d79eb0f