### PR TITLE
feat(web): add server root router

### DIFF
--- a/apps/web/src/server/root.spec.ts
+++ b/apps/web/src/server/root.spec.ts
@@ -1,0 +1,12 @@
+import { createCaller } from './root';
+import { runServerContext } from './context';
+
+describe('root router', () => {
+  it('exposes ping procedure', async () => {
+    const ctx = { requestId: 'xyz' };
+    const caller = createCaller(ctx);
+    await expect(runServerContext(ctx, () => caller.ping())).resolves.toEqual({
+      requestId: 'xyz',
+    });
+  });
+});

--- a/apps/web/src/server/root.ts
+++ b/apps/web/src/server/root.ts
@@ -1,0 +1,28 @@
+'use strict';
+
+import { initTRPC } from '@trpc/server';
+
+import { useServerContext, type ServerContextValue } from './context';
+
+export type RootContext = ServerContextValue;
+
+const t = initTRPC.context<RootContext>().create();
+
+/**
+ * Root tRPC router for all server procedures.
+ */
+export const rootRouter = t.router({
+  /**
+   * Simple ping endpoint.
+   *
+   * @returns Request identifier from context.
+   */
+  ping: t.procedure.query(() => {
+    const { requestId } = useServerContext();
+    return { requestId };
+  }),
+});
+
+export type RootRouter = typeof rootRouter;
+
+export const createCaller = rootRouter.createCaller;

--- a/apps/web/src/server/trpc.ts
+++ b/apps/web/src/server/trpc.ts
@@ -1,17 +1,13 @@
 'use strict';
 
-import { initTRPC } from '@trpc/server';
 import {
   fetchRequestHandler,
   FetchCreateContextFnOptions,
 } from '@trpc/server/adapters/fetch';
 import { randomUUID } from 'node:crypto';
 
-import {
-  runServerContext,
-  useServerContext,
-  type ServerContextValue,
-} from './context';
+import { runServerContext, type ServerContextValue } from './context';
+import { rootRouter } from './root';
 
 export type TrpcContext = ServerContextValue;
 
@@ -21,24 +17,13 @@ export async function createContext({
   return { requestId: req.headers.get('x-request-id') ?? randomUUID() };
 }
 
-const t = initTRPC.context<TrpcContext>().create();
-
-export const appRouter = t.router({
-  ping: t.procedure.query(() => {
-    const { requestId } = useServerContext();
-    return { requestId };
-  }),
-});
-
-export type AppRouter = typeof appRouter;
-
 export async function handleTrpcRequest(request: Request) {
   const ctx = await createContext({ req: request, resHeaders: new Headers() });
   return runServerContext(ctx, () =>
     fetchRequestHandler({
       endpoint: '/api/trpc',
       req: request,
-      router: appRouter,
+      router: rootRouter,
       createContext: () => ctx,
     })
   );


### PR DESCRIPTION
## Why
Provide a single entry point for all tRPC procedures and enable tests to call server APIs directly.

## Notes
- Added `rootRouter` with a simple ping procedure.
- Updated `trpc.ts` to use the new router.
- Added unit test verifying `rootRouter` behaviour.


------
https://chatgpt.com/codex/tasks/task_e_6858246eebb083269f6002dc8dbd7806

## Summary by Sourcery

Provide a unified server root router for all tRPC procedures, update request handling to use the new router, and add tests for its ping endpoint.

New Features:
- Introduce rootRouter as the central tRPC entry point with a ping procedure

Enhancements:
- Switch handleTrpcRequest to use rootRouter and remove appRouter
- Export createCaller utility for direct server-side invocation

Tests:
- Add unit tests to validate rootRouter's ping endpoint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new server endpoint that allows retrieval of the current request identifier.
- **Tests**
  - Added tests to verify the correct behaviour of the new server endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->