### PR TITLE
feat(server): add root router

### DIFF
--- a/apps/web/src/server/router.spec.ts
+++ b/apps/web/src/server/router.spec.ts
@@ -1,0 +1,11 @@
+import { rootRouter } from './router';
+import { runServerContext } from './context';
+
+describe('rootRouter', () => {
+  it('resolves ping using context', async () => {
+    const res = await runServerContext({ requestId: 'abc' }, () =>
+      rootRouter.createCaller({ requestId: 'abc' }).ping()
+    );
+    expect(res).toEqual({ requestId: 'abc' });
+  });
+});

--- a/apps/web/src/server/router.ts
+++ b/apps/web/src/server/router.ts
@@ -1,0 +1,20 @@
+'use strict';
+
+import { initTRPC } from '@trpc/server';
+
+import { useServerContext, type ServerContextValue } from './context';
+
+const t = initTRPC.context<ServerContextValue>().create();
+
+/**
+ * Root router for all server procedures.
+ */
+export const rootRouter = t.router({
+  /** Check server context propagation. */
+  ping: t.procedure.query(() => {
+    const { requestId } = useServerContext();
+    return { requestId };
+  }),
+});
+
+export type RootRouter = typeof rootRouter;

--- a/apps/web/src/server/trpc.ts
+++ b/apps/web/src/server/trpc.ts
@@ -1,17 +1,13 @@
 'use strict';
 
-import { initTRPC } from '@trpc/server';
 import {
   fetchRequestHandler,
   FetchCreateContextFnOptions,
 } from '@trpc/server/adapters/fetch';
 import { randomUUID } from 'node:crypto';
 
-import {
-  runServerContext,
-  useServerContext,
-  type ServerContextValue,
-} from './context';
+import { runServerContext, type ServerContextValue } from './context';
+import { rootRouter } from './router';
 
 export type TrpcContext = ServerContextValue;
 
@@ -21,14 +17,7 @@ export async function createContext({
   return { requestId: req.headers.get('x-request-id') ?? randomUUID() };
 }
 
-const t = initTRPC.context<TrpcContext>().create();
-
-export const appRouter = t.router({
-  ping: t.procedure.query(() => {
-    const { requestId } = useServerContext();
-    return { requestId };
-  }),
-});
+export const appRouter = rootRouter;
 
 export type AppRouter = typeof appRouter;
 


### PR DESCRIPTION
## Why
- centralize server API entry point

## Changes
- create server root router
- refactor TRPC setup to use it
- add unit test for router

## Notes
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68582bcc73608326839f5d54db891c62

## Summary by Sourcery

Introduce a centralized root TRPC router and refactor the server TRPC setup to delegate to it, with accompanying unit tests for router procedures.

New Features:
- Add a rootRouter as the central TRPC API entry point

Enhancements:
- Refactor appRouter in trpc.ts to use the new rootRouter implementation

Tests:
- Add unit tests for the rootRouter ping procedure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a server router with a `ping` procedure that returns the current request ID.
- **Tests**
  - Added tests to verify that the `ping` procedure correctly returns the request ID from the server context.
- **Refactor**
  - Centralised router logic into a dedicated module for improved organisation and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->