### PR TITLE
feat(web): add server root router

### DIFF
--- a/apps/web/src/server/root-router.spec.ts
+++ b/apps/web/src/server/root-router.spec.ts
@@ -1,0 +1,12 @@
+import { appRouter } from './root-router';
+import { runServerContext } from './context';
+
+describe('appRouter', () => {
+  it('resolves ping with context id', async () => {
+    const caller = appRouter.createCaller({ requestId: 'abc' });
+    const result = await runServerContext({ requestId: 'abc' }, () =>
+      caller.ping()
+    );
+    expect(result).toEqual({ requestId: 'abc' });
+  });
+});

--- a/apps/web/src/server/root-router.ts
+++ b/apps/web/src/server/root-router.ts
@@ -1,0 +1,23 @@
+'use strict';
+
+import { initTRPC } from '@trpc/server';
+
+import { useServerContext, type ServerContextValue } from './context';
+
+export type TrpcContext = ServerContextValue;
+
+const trpc = initTRPC.context<TrpcContext>().create();
+
+/**
+ * Root tRPC router exposing all server procedures.
+ */
+export const appRouter = trpc.router({
+  ping: trpc.procedure.query(() => {
+    const { requestId } = useServerContext();
+    return { requestId };
+  }),
+});
+
+export type AppRouter = typeof appRouter;
+
+export { trpc };

--- a/apps/web/src/server/trpc.ts
+++ b/apps/web/src/server/trpc.ts
@@ -1,19 +1,15 @@
 'use strict';
 
-import { initTRPC } from '@trpc/server';
 import {
   fetchRequestHandler,
   FetchCreateContextFnOptions,
 } from '@trpc/server/adapters/fetch';
 import { randomUUID } from 'node:crypto';
 
-import {
-  runServerContext,
-  useServerContext,
-  type ServerContextValue,
-} from './context';
+import { runServerContext } from './context';
+import { appRouter, type TrpcContext } from './root-router';
 
-export type TrpcContext = ServerContextValue;
+export type { TrpcContext };
 
 export async function createContext({
   req,
@@ -21,16 +17,7 @@ export async function createContext({
   return { requestId: req.headers.get('x-request-id') ?? randomUUID() };
 }
 
-const t = initTRPC.context<TrpcContext>().create();
-
-export const appRouter = t.router({
-  ping: t.procedure.query(() => {
-    const { requestId } = useServerContext();
-    return { requestId };
-  }),
-});
-
-export type AppRouter = typeof appRouter;
+export type { AppRouter } from './root-router';
 
 export async function handleTrpcRequest(request: Request) {
   const ctx = await createContext({ req: request, resHeaders: new Headers() });


### PR DESCRIPTION
## Why
- lay the groundwork for future tRPC procedures by extracting a dedicated root router

## Notes
- `yarn nx run-many --target=test` and `yarn test` both pass

Labels: release:patch

------
https://chatgpt.com/codex/tasks/task_e_68582bcc73608326839f5d54db891c62

## Summary by Sourcery

Extract the root tRPC router into a dedicated module and update the server entry to use the new router, laying the groundwork for future procedure additions.

New Features:
- Add a new root-router.ts file defining the central tRPC router and exporting its types and procedures

Enhancements:
- Refactor trpc.ts to import and re-export the appRouter and context types from root-router.ts
- Simplify context import in createContext to remove redundant server context hooks

Tests:
- Add root-router.spec.ts as the test entrypoint for the new root-router module

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new server router with a "ping" endpoint that returns the current request ID.
- **Tests**
  - Added tests to verify the correct behaviour of the "ping" endpoint.
- **Refactor**
  - Streamlined server setup by moving router and context logic to a dedicated module for improved organisation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->