### PR TITLE
feat(web): add tRPC client helpers

### DIFF
--- a/apps/web/src/client/trpc.spec.tsx
+++ b/apps/web/src/client/trpc.spec.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { httpBatchLink } from '@trpc/client';
+
+import { createTrpcClient, TrpcProvider } from './trpc';
+
+jest.mock('@trpc/client', () => ({
+  httpBatchLink: jest.fn(() => jest.fn()),
+}));
+jest.mock('@trpc/react-query', () => ({
+  createTRPCReact: () => ({
+    createClient: jest.fn(() => ({
+      foo: 'bar',
+    })),
+    Provider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  }),
+}));
+
+describe('createTrpcClient', () => {
+  it('configures httpBatchLink with API path', () => {
+    createTrpcClient();
+    expect(httpBatchLink).toHaveBeenCalledWith({ url: '/api/trpc' });
+  });
+});
+
+describe('TrpcProvider', () => {
+  it('renders child elements', () => {
+    const { getByText } = render(
+      <TrpcProvider>
+        <span>works</span>
+      </TrpcProvider>
+    );
+    expect(getByText('works')).toBeTruthy();
+  });
+});

--- a/apps/web/src/client/trpc.tsx
+++ b/apps/web/src/client/trpc.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { httpBatchLink } from '@trpc/client';
+import { createTRPCReact } from '@trpc/react-query';
+import { QueryClient } from '@tanstack/react-query';
+import { useState, type ReactNode } from 'react';
+
+import type { AppRouter } from '../server/trpc';
+
+/**
+ * tRPC React context and helpers.
+ */
+export const trpc = createTRPCReact<AppRouter>();
+
+/**
+ * Create a tRPC client bound to `/api/trpc`.
+ *
+ * @returns Configured client instance.
+ */
+export function createTrpcClient() {
+  return trpc.createClient({
+    links: [httpBatchLink({ url: '/api/trpc' })],
+  } as unknown as Parameters<typeof trpc.createClient>[0]);
+}
+
+export interface TrpcProviderProps {
+  /** Elements to render inside the provider */
+  children: ReactNode;
+}
+
+/**
+ * Provide tRPC and React Query context.
+ *
+ * @param props - Component properties.
+ * @returns Wrapped elements.
+ */
+export function TrpcProvider({ children }: TrpcProviderProps) {
+  const [queryClient] = useState(() => new QueryClient());
+  const [client] = useState(createTrpcClient);
+
+  return (
+    <trpc.Provider client={client} queryClient={queryClient}>
+      {children}
+    </trpc.Provider>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -72,6 +72,9 @@
   },
   "dependencies": {
     "@engie-group/fluid-design-system": "^5.17.2",
+    "@tanstack/react-query": "^4",
+    "@trpc/client": "10.45.0",
+    "@trpc/react-query": "10.45.0",
     "@trpc/server": "10.45.0",
     "axios": "^1.6.0",
     "next": "~15.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4899,6 +4899,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tanstack/query-core@npm:4.40.0":
+  version: 4.40.0
+  resolution: "@tanstack/query-core@npm:4.40.0"
+  checksum: 10c0/c04ebaae3b30d59fcf647c3e3aed95bc7aea632a37088f6066b9958ac2144613ed545471e9ecefd78b1ebe2536fbc74eb708f8614334d012156d82aabfef5fd6
+  languageName: node
+  linkType: hard
+
+"@tanstack/react-query@npm:^4":
+  version: 4.40.0
+  resolution: "@tanstack/react-query@npm:4.40.0"
+  dependencies:
+    "@tanstack/query-core": "npm:4.40.0"
+    use-sync-external-store: "npm:^1.2.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-native: "*"
+  peerDependenciesMeta:
+    react-dom:
+      optional: true
+    react-native:
+      optional: true
+  checksum: 10c0/e8f518cee298d3594267842ee21dd7f1d086b75308cd5700da586d49b488f854eeb91c48fa6cec004bb9afcdead8bbcc01412f8861bc760abc80b84bc5355b16
+  languageName: node
+  linkType: hard
+
 "@testing-library/dom@npm:10.4.0":
   version: 10.4.0
   resolution: "@testing-library/dom@npm:10.4.0"
@@ -4946,6 +4972,28 @@ __metadata:
   version: 2.0.0
   resolution: "@tootallnate/once@npm:2.0.0"
   checksum: 10c0/073bfa548026b1ebaf1659eb8961e526be22fa77139b10d60e712f46d2f0f05f4e6c8bec62a087d41088ee9e29faa7f54838568e475ab2f776171003c3920858
+  languageName: node
+  linkType: hard
+
+"@trpc/client@npm:10.45.0":
+  version: 10.45.0
+  resolution: "@trpc/client@npm:10.45.0"
+  peerDependencies:
+    "@trpc/server": 10.45.0
+  checksum: 10c0/f8df80923fd9bde42a657e6bcfb6dba79cac442f24a4d638290833fe08dc198cae1c185a99787de47667398b48a0ae04fab30985bc3698e8382515d6167302d5
+  languageName: node
+  linkType: hard
+
+"@trpc/react-query@npm:10.45.0":
+  version: 10.45.0
+  resolution: "@trpc/react-query@npm:10.45.0"
+  peerDependencies:
+    "@tanstack/react-query": ^4.18.0
+    "@trpc/client": 10.45.0
+    "@trpc/server": 10.45.0
+    react: ">=16.8.0"
+    react-dom: ">=16.8.0"
+  checksum: 10c0/768a1da7acb6061995d4004649275c6828b3224d4e0a1020ba1208bcdd49cbdfcbe2e48da185ce0dbdb9e845ba69252c12eb996a011c8bf92ce5477f4f2ca6a9
   languageName: node
   linkType: hard
 
@@ -8338,8 +8386,11 @@ __metadata:
     "@swc/cli": "npm:~0.6.0"
     "@swc/core": "npm:~1.5.7"
     "@swc/helpers": "npm:~0.5.11"
+    "@tanstack/react-query": "npm:^4"
     "@testing-library/dom": "npm:10.4.0"
     "@testing-library/react": "npm:16.1.0"
+    "@trpc/client": "npm:10.45.0"
+    "@trpc/react-query": "npm:10.45.0"
     "@trpc/server": "npm:10.45.0"
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:18.16.9"
@@ -17210,6 +17261,15 @@ __metadata:
     querystringify: "npm:^2.1.1"
     requires-port: "npm:^1.0.0"
   checksum: 10c0/bd5aa9389f896974beb851c112f63b466505a04b4807cea2e5a3b7092f6fbb75316f0491ea84e44f66fed55f1b440df5195d7e3a8203f64fcefa19d182f5be87
+  languageName: node
+  linkType: hard
+
+"use-sync-external-store@npm:^1.2.0":
+  version: 1.5.0
+  resolution: "use-sync-external-store@npm:1.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10c0/1b8663515c0be34fa653feb724fdcce3984037c78dd4a18f68b2c8be55cc1a1084c578d5b75f158d41b5ddffc2bf5600766d1af3c19c8e329bb20af2ec6f52f4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Why
Adds a typed client and provider for tRPC so UI components can easily call server procedures.

## Notes
- new dependencies installed for tRPC client integration
- all lint, format, type-check, and tests pass


------
https://chatgpt.com/codex/tasks/task_e_68586158bfd483269eafc51f094335c3

## Summary by Sourcery

Provide a typed tRPC React client and provider for UI components to call server procedures.

New Features:
- Add `createTrpcClient` helper for instantiating a tRPC client bound to `/api/trpc`.
- Add `TrpcProvider` component to wrap UI with tRPC and React Query context.
- Expose a `trpc` React context generated from the server `AppRouter`.

Enhancements:
- Install and configure `@tanstack/react-query`, `@trpc/client`, and `@trpc/react-query` dependencies.

Tests:
- Add initial `trpc.spec.tsx` test file for client helpers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced tRPC integration for the web client, enabling seamless API communication and React Query support via a new provider component.
- **Tests**
	- Added unit tests for the tRPC client setup and provider to ensure correct configuration and rendering.
- **Chores**
	- Added new dependencies for tRPC and React Query to support the new integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->