### PR TITLE
feat(web): add trpc client helpers

### DIFF
--- a/apps/web/src/client/trpc-client.spec.ts
+++ b/apps/web/src/client/trpc-client.spec.ts
@@ -1,0 +1,20 @@
+import { createTrpcClient } from './trpc-client';
+
+jest.mock('@trpc/client', () => ({
+  createTRPCProxyClient: jest.fn(),
+  httpBatchLink: jest.fn(() => 'link'),
+}));
+
+describe('createTrpcClient', () => {
+  it('passes baseUrl to httpBatchLink', () => {
+    const { httpBatchLink, createTRPCProxyClient } = require('@trpc/client');
+    createTrpcClient('https://api.example.com');
+    expect(httpBatchLink).toHaveBeenCalledWith({
+      url: 'https://api.example.com/api/trpc',
+    });
+    expect(createTRPCProxyClient).toHaveBeenCalledWith({
+      transformer: expect.any(Object),
+      links: ['link'],
+    });
+  });
+});

--- a/apps/web/src/client/trpc-client.spec.ts
+++ b/apps/web/src/client/trpc-client.spec.ts
@@ -17,4 +17,12 @@ describe('createTrpcClient', () => {
       links: ['link'],
     });
   });
+
+  it('omits trailing slash from baseUrl', () => {
+    const { httpBatchLink } = require('@trpc/client');
+    createTrpcClient('https://api.example.com/');
+    expect(httpBatchLink).toHaveBeenLastCalledWith({
+      url: 'https://api.example.com/api/trpc',
+    });
+  });
 });

--- a/apps/web/src/client/trpc-client.ts
+++ b/apps/web/src/client/trpc-client.ts
@@ -16,8 +16,9 @@ const transformer: DataTransformerOptions = {
  * @returns Configured tRPC client.
  */
 export function createTrpcClient(baseUrl = '') {
+  const normalized = baseUrl.replace(/\/$/, '');
   return createTRPCProxyClient<AppRouter>({
     transformer,
-    links: [httpBatchLink({ url: `${baseUrl}/api/trpc` })],
+    links: [httpBatchLink({ url: `${normalized}/api/trpc` })],
   });
 }

--- a/apps/web/src/client/trpc-client.ts
+++ b/apps/web/src/client/trpc-client.ts
@@ -1,0 +1,23 @@
+'use strict';
+
+import { createTRPCProxyClient, httpBatchLink } from '@trpc/client';
+import type { DataTransformerOptions } from '@trpc/server';
+import type { AppRouter } from '../server/trpc';
+
+const transformer: DataTransformerOptions = {
+  input: { serialize: (d) => d, deserialize: (d) => d },
+  output: { serialize: (d) => d, deserialize: (d) => d },
+};
+
+/**
+ * Create a tRPC client for the browser.
+ *
+ * @param baseUrl - Optional base URL for API requests.
+ * @returns Configured tRPC client.
+ */
+export function createTrpcClient(baseUrl = '') {
+  return createTRPCProxyClient<AppRouter>({
+    transformer,
+    links: [httpBatchLink({ url: `${baseUrl}/api/trpc` })],
+  });
+}

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   },
   "dependencies": {
     "@engie-group/fluid-design-system": "^5.17.2",
+    "@trpc/client": "10.45.0",
     "@trpc/server": "10.45.0",
     "axios": "^1.6.0",
     "next": "~15.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4949,6 +4949,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@trpc/client@npm:10.45.0":
+  version: 10.45.0
+  resolution: "@trpc/client@npm:10.45.0"
+  peerDependencies:
+    "@trpc/server": 10.45.0
+  checksum: 10c0/f8df80923fd9bde42a657e6bcfb6dba79cac442f24a4d638290833fe08dc198cae1c185a99787de47667398b48a0ae04fab30985bc3698e8382515d6167302d5
+  languageName: node
+  linkType: hard
+
 "@trpc/server@npm:10.45.0":
   version: 10.45.0
   resolution: "@trpc/server@npm:10.45.0"
@@ -8340,6 +8349,7 @@ __metadata:
     "@swc/helpers": "npm:~0.5.11"
     "@testing-library/dom": "npm:10.4.0"
     "@testing-library/react": "npm:16.1.0"
+    "@trpc/client": "npm:10.45.0"
     "@trpc/server": "npm:10.45.0"
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:18.16.9"


### PR DESCRIPTION
## Why
- need easy access to tRPC procedures on the web app

## Summary
- add `@trpc/client` dependency
- implement `createTrpcClient` helper
- test client initialization

## Testing
- `yarn nx run-many --target=test --output-style=static`

------
https://chatgpt.com/codex/tasks/task_e_68586158bfd483269eafc51f094335c3

## Summary by Sourcery

Introduce a tRPC client helper for the web app by adding the @trpc/client dependency, implementing a createTrpcClient function with sensible defaults, and covering its initialization with tests.

New Features:
- Add @trpc/client dependency to enable tRPC client usage in the web app
- Implement createTrpcClient helper that configures a tRPC proxy client with HTTP batching

Tests:
- Add unit tests to verify createTrpcClient initializes correctly with default and custom base URLs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a function for creating a tRPC client, enabling browser-based communication with the server.
- **Tests**
	- Added tests to verify correct configuration of the tRPC client.
- **Chores**
	- Added the "@trpc/client" dependency to the project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->