### PR TITLE
feat(web): fix Next.js build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Type check
         run: yarn ts:check
 
+      - name: Build
+        run: yarn nx run-many --target=build --all
+
       - name: Unit tests
         run: yarn nx run-many --target=test
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Release Checks
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  checklist:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'yarn'
+          cache-dependency-path: '**/yarn.lock'
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Nx affected
+        run: yarn nx affected --target=test,lint,build
+
+      - name: Prisma validate
+        run: |
+          docker build -t app .
+          docker run --rm app yarn prisma validate
+

--- a/apps/web/src/app/api/hello/route.ts
+++ b/apps/web/src/app/api/hello/route.ts
@@ -1,3 +1,6 @@
-export async function GET(request: Request) {
+export const runtime = 'edge';
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
   return new Response('Hello, from electric MDD UK API!');
 }

--- a/apps/web/src/server/trpc.ts
+++ b/apps/web/src/server/trpc.ts
@@ -4,8 +4,7 @@ import {
   fetchRequestHandler,
   FetchCreateContextFnOptions,
 } from '@trpc/server/adapters/fetch';
-import { randomUUID } from 'node:crypto';
-
+// Use global Web Crypto API to support the Edge runtime
 import { runServerContext } from './context';
 import { appRouter, type TrpcContext } from './root-router';
 
@@ -14,7 +13,9 @@ export type { TrpcContext };
 export async function createContext({
   req,
 }: FetchCreateContextFnOptions): Promise<TrpcContext> {
-  return { requestId: req.headers.get('x-request-id') ?? randomUUID() };
+  return {
+    requestId: req.headers.get('x-request-id') ?? crypto.randomUUID(),
+  };
 }
 
 export type { AppRouter } from './root-router';


### PR DESCRIPTION
## Why
Handle edge runtime correctly so builds succeed.

## Labels
release:patch

------
https://chatgpt.com/codex/tasks/task_e_685908d758888326887f83c6f253a439

## Summary by Sourcery

Fix Next.js build by configuring edge runtime and dynamic settings for API routes, updating request ID generation, and extending CI with build and release checks

Enhancements:
- Configure the Hello API route to use Edge runtime and force dynamic rendering
- Switch request ID generation to use crypto.randomUUID() in the TRPC context

CI:
- Add a build step to the main CI workflow
- Introduce a new release checks workflow with Nx affected tasks and Prisma validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Added a build step to the continuous integration workflow.
	- Introduced a new release validation workflow to automate testing, linting, building, and schema validation before releases.

- **New Features**
	- API route now explicitly configured to run on the edge runtime with dynamic rendering enforced.

- **Refactor**
	- Improved compatibility with edge environments by switching to the global Web Crypto API for generating unique request IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->