### PR TITLE
feat(web): add global Fluid layout

### DIFF
--- a/apps/web/specs/layout.spec.tsx
+++ b/apps/web/specs/layout.spec.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import RootLayout from '../src/app/layout';
+
+describe('RootLayout', () => {
+  it('renders children', () => {
+    const { baseElement } = render(
+      <RootLayout>
+        <p>Test Child</p>
+      </RootLayout>,
+      { container: document.documentElement }
+    );
+    expect(baseElement).toBeTruthy();
+  });
+});

--- a/apps/web/src/app/components/FluidProvider.tsx
+++ b/apps/web/src/app/components/FluidProvider.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import { ReactNode } from 'react';
+import '@engie-group/fluid-design-system/auto-init';
+
+/**
+ * Wraps children to initialise Fluid Design System components.
+ */
+export default function FluidProvider({ children }: { children: ReactNode }) {
+  return <>{children}</>;
+}

--- a/apps/web/src/app/global.css
+++ b/apps/web/src/app/global.css
@@ -1,3 +1,6 @@
+@import '@engie-group/fluid-design-tokens/css';
+@import '@engie-group/fluid-design-system/css';
+
 html {
   -webkit-text-size-adjust: 100%;
   font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import './global.css';
+import FluidProvider from './components/FluidProvider';
 
 export const metadata = {
   title: 'Welcome to electric MDD UK',
@@ -11,7 +12,9 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <FluidProvider>{children}</FluidProvider>
+      </body>
     </html>
   );
 }


### PR DESCRIPTION
## Why
- initialize Fluid components for consistent UI

## Changes
- import Fluid CSS globally
- wrap app with a FluidProvider
- add unit test for the root layout

------
https://chatgpt.com/codex/tasks/task_e_685a6d145a38832682d7f2c621c092d6