### PR TITLE
feat(web): add connection wizard route

### DIFF
--- a/apps/web/specs/connection-wizard.spec.tsx
+++ b/apps/web/specs/connection-wizard.spec.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ConnectionWizardPage from '../src/app/connection-wizard/page';
+
+describe('ConnectionWizardPage', () => {
+  it('renders heading', () => {
+    render(<ConnectionWizardPage />);
+    const heading = screen.getByRole('heading', {
+      name: /connection wizard/i,
+    });
+    expect(heading).toBeTruthy();
+  });
+});

--- a/apps/web/src/app/connection-wizard/page.tsx
+++ b/apps/web/src/app/connection-wizard/page.tsx
@@ -1,0 +1,16 @@
+'use strict';
+
+/**
+ * Show the connection wizard entry page.
+ */
+export default function ConnectionWizardPage() {
+  return (
+    <section className="p-6">
+      <h1>Connection wizard ⚡️</h1>
+      <p>Follow the steps to set up your new connection.</p>
+      <button type="button" className="nj-btn">
+        Start
+      </button>
+    </section>
+  );
+}


### PR DESCRIPTION
## Why
Adds an entry point for the connection wizard in the web app so users can begin the guided setup.

## Notes
- label: `release:minor`

------
https://chatgpt.com/codex/tasks/task_e_685aa0fcf7fc83268ad608c269d76e63