### PR TITLE
feat(web): add wizard state hook

### DIFF
--- a/apps/web/src/app/connection-wizard/useWizardState.spec.tsx
+++ b/apps/web/src/app/connection-wizard/useWizardState.spec.tsx
@@ -11,7 +11,7 @@ describe('useWizardState', () => {
     expect(result.current.step).toBe(1);
 
     act(() => {
-      result.current.next();
+      result.current.goTo(2);
     });
     expect(result.current.isLastStep).toBe(true);
 
@@ -19,5 +19,10 @@ describe('useWizardState', () => {
       result.current.back();
     });
     expect(result.current.step).toBe(1);
+
+    act(() => {
+      result.current.reset();
+    });
+    expect(result.current.step).toBe(0);
   });
 });

--- a/apps/web/src/app/connection-wizard/useWizardState.ts
+++ b/apps/web/src/app/connection-wizard/useWizardState.ts
@@ -8,8 +8,9 @@ import { useCallback, useState } from 'react';
  * @param totalSteps - Number of steps in the wizard.
  * @returns Wizard state helpers.
  */
-export function useWizardState(totalSteps: number) {
-  const [step, setStep] = useState(0);
+export function useWizardState(totalSteps: number, initialStep = 0) {
+  const normalised = Math.min(Math.max(initialStep, 0), totalSteps - 1);
+  const [step, setStep] = useState(normalised);
 
   const next = useCallback(() => {
     setStep((s) => Math.min(s + 1, totalSteps - 1));
@@ -26,6 +27,10 @@ export function useWizardState(totalSteps: number) {
     [totalSteps]
   );
 
+  const reset = useCallback(() => {
+    setStep(0);
+  }, []);
+
   return {
     step,
     isFirstStep: step === 0,
@@ -33,5 +38,6 @@ export function useWizardState(totalSteps: number) {
     next,
     back,
     goTo,
+    reset,
   } as const;
 }


### PR DESCRIPTION
## Why
Enables step management for the connection wizard via a reusable hook.

## Notes
- Adds unit test for the hook.


------
https://chatgpt.com/codex/tasks/task_e_685b0742c3008326a7c8cd05e3cce8c0

## Summary by Sourcery

Provide a reusable React hook for managing connection wizard steps, including navigation helpers (next, back, goTo) and state flags (isFirstStep, isLastStep), and include unit tests to validate its behavior.

New Features:
- Introduce useWizardState hook to manage wizard navigation and step state

Tests:
- Add unit tests for useWizardState hook to verify step transitions and boundary conditions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a wizard navigation system enabling users to progress, return, or jump between steps in a multi-step process.
- **Tests**
  - Added comprehensive tests to validate step navigation, including advancing, reversing, direct jumps, and boundary conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->