### PR TITLE
feat(web): add wizard state hook

### DIFF
--- a/apps/web/src/app/connection-wizard/useWizardState.spec.tsx
+++ b/apps/web/src/app/connection-wizard/useWizardState.spec.tsx
@@ -1,0 +1,23 @@
+import { act, renderHook } from '@testing-library/react';
+import { useWizardState } from './useWizardState';
+
+describe('useWizardState', () => {
+  it('navigates steps', () => {
+    const { result } = renderHook(() => useWizardState(3));
+
+    act(() => {
+      result.current.goTo(1);
+    });
+    expect(result.current.step).toBe(1);
+
+    act(() => {
+      result.current.next();
+    });
+    expect(result.current.isLastStep).toBe(true);
+
+    act(() => {
+      result.current.goTo(-2);
+    });
+    expect(result.current.isFirstStep).toBe(true);
+  });
+});

--- a/apps/web/src/app/connection-wizard/useWizardState.ts
+++ b/apps/web/src/app/connection-wizard/useWizardState.ts
@@ -1,0 +1,37 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+
+/**
+ * Manage the current step of the connection wizard.
+ *
+ * @param totalSteps - Number of steps in the wizard.
+ * @returns Wizard state helpers.
+ */
+export function useWizardState(totalSteps: number) {
+  const [step, setStep] = useState(0);
+
+  const next = useCallback(() => {
+    setStep((s) => Math.min(s + 1, totalSteps - 1));
+  }, [totalSteps]);
+
+  const back = useCallback(() => {
+    setStep((s) => Math.max(s - 1, 0));
+  }, []);
+
+  const goTo = useCallback(
+    (index: number) => {
+      setStep(Math.min(Math.max(index, 0), totalSteps - 1));
+    },
+    [totalSteps]
+  );
+
+  return {
+    step,
+    isFirstStep: step === 0,
+    isLastStep: step === totalSteps - 1,
+    next,
+    back,
+    goTo,
+  } as const;
+}


### PR DESCRIPTION
## Why
Adds a simple state manager for navigating wizard steps.

## Notes
- Includes unit tests for the hook.

------
https://chatgpt.com/codex/tasks/task_e_685b0742c3008326a7c8cd05e3cce8c0

## Summary by Sourcery

Add a custom React hook for managing wizard step state and corresponding navigation actions, along with unit tests.

New Features:
- Introduce useWizardState hook to track and navigate through wizard steps.
- Expose step index, boundary flags, and navigation methods (next, back, goTo) as a constant-return API.

Tests:
- Add unit tests to validate step boundaries and navigation behavior of the useWizardState hook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a multi-step navigation feature for connection wizards, allowing users to move forward, backward, or jump to specific steps.
- **Tests**
  - Added tests to ensure correct step navigation and boundary handling in the wizard flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->