### PR TITLE
feat(web): add wizard shell

### DIFF
--- a/apps/mdd-loader-e2e/src/mdd-loader/mdd-loader.spec.ts
+++ b/apps/mdd-loader-e2e/src/mdd-loader/mdd-loader.spec.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'child_process';
-import { join } from 'path';
+import { join } from 'node:path';
 
 describe('CLI tests', () => {
   it('runs the seed script', () => {

--- a/apps/web/src/app/connection-wizard/WizardShell.spec.tsx
+++ b/apps/web/src/app/connection-wizard/WizardShell.spec.tsx
@@ -1,0 +1,22 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import WizardShell from './WizardShell';
+
+function Step({ label }: { label: string }) {
+  return <p>{label}</p>;
+}
+
+describe('WizardShell', () => {
+  it('navigates through steps', async () => {
+    render(
+      <WizardShell
+        steps={[<Step key="one" label="one" />, <Step key="two" label="two" />]}
+      />
+    );
+
+    expect(screen.getByText('one')).toBeTruthy();
+    fireEvent.click(screen.getByText('Next'));
+    expect(screen.getByText('two')).toBeTruthy();
+    fireEvent.click(screen.getByText('Back'));
+    expect(screen.getByText('one')).toBeTruthy();
+  });
+});

--- a/apps/web/src/app/connection-wizard/WizardShell.tsx
+++ b/apps/web/src/app/connection-wizard/WizardShell.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { PropsWithChildren } from 'react';
+import { useWizardState } from './useWizardState';
+
+/**
+ * Render a minimal multi-step wizard shell.
+ *
+ * @param steps - Ordered list of wizard steps.
+ * @param onFinish - Called when the last step completes.
+ */
+export default function WizardShell({
+  steps,
+  onFinish,
+}: PropsWithChildren<{ steps: React.ReactElement[]; onFinish?: () => void }>) {
+  const { step, next, back, isFirstStep, isLastStep } = useWizardState(
+    steps.length
+  );
+
+  const handleNext = () => {
+    if (isLastStep) {
+      onFinish?.();
+      return;
+    }
+    next();
+  };
+
+  return (
+    <section className="p-6">
+      {steps[step]}
+      <nav className="mt-4 flex gap-2">
+        {!isFirstStep && (
+          <button
+            type="button"
+            onClick={back}
+            className="nj-btn nj-btn--inverse"
+          >
+            Back
+          </button>
+        )}
+        <button type="button" onClick={handleNext} className="nj-btn">
+          {isLastStep ? 'Finish' : 'Next'}
+        </button>
+      </nav>
+    </section>
+  );
+}

--- a/apps/web/src/app/connection-wizard/page.tsx
+++ b/apps/web/src/app/connection-wizard/page.tsx
@@ -1,16 +1,23 @@
-'use strict';
+'use client';
+
+import WizardShell from './WizardShell';
 
 /**
  * Show the connection wizard entry page.
  */
 export default function ConnectionWizardPage() {
   return (
-    <section className="p-6">
-      <h1>Connection wizard ⚡️</h1>
-      <p>Follow the steps to set up your new connection.</p>
-      <button type="button" className="nj-btn">
-        Start
-      </button>
-    </section>
+    <WizardShell
+      steps={[
+        <section key="intro">
+          <h1>Connection wizard ⚡️</h1>
+          <p>Follow the steps to set up your new connection.</p>
+        </section>,
+        <section key="confirm">
+          <h1>All done 🎉</h1>
+          <p>You completed the wizard.</p>
+        </section>,
+      ]}
+    />
   );
 }


### PR DESCRIPTION
## Why
- start building the connection wizard UI

## What
- add `WizardShell` component to drive navigation
- update wizard page to use the shell
- test navigation logic

------
https://chatgpt.com/codex/tasks/task_e_685b1948a9508326a2eccb5a507f7844

## Summary by Sourcery

Introduce a shell component to drive multi-step connection wizard navigation and update the page to use this component with accompanying tests.

New Features:
- Introduce WizardShell component for multi-step wizard navigation.
- Integrate WizardShell into ConnectionWizardPage with predefined wizard steps.

Tests:
- Add unit tests to verify WizardShell navigates between steps correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a multi-step wizard interface for the connection wizard page, allowing users to navigate through steps with "Back" and "Next/Finish" buttons.

- **Tests**
  - Added tests to verify navigation through the wizard steps, ensuring correct behaviour of step transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->