### PR TITLE
feat(web): add basics form step

### DIFF
--- a/apps/mdd-loader-e2e/src/mdd-loader/mdd-loader.spec.ts
+++ b/apps/mdd-loader-e2e/src/mdd-loader/mdd-loader.spec.ts
@@ -1,9 +1,10 @@
 import { execFileSync } from 'child_process';
 import { join } from 'node:path';
+import { workspaceRoot } from 'nx/src/utils/workspace-root';
 
 describe('CLI tests', () => {
   it('runs the seed script', () => {
-    const cliPath = join(process.cwd(), 'dist/apps/mdd-loader/cli.js');
+    const cliPath = join(workspaceRoot, 'dist/apps/mdd-loader/cli.js');
 
     const output = execFileSync('node', [cliPath]).toString();
 

--- a/apps/web/src/app/connection-wizard/BasicsStep.spec.tsx
+++ b/apps/web/src/app/connection-wizard/BasicsStep.spec.tsx
@@ -1,0 +1,11 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import BasicsStep from './BasicsStep';
+
+describe('BasicsStep', () => {
+  it('validates fields on blur', () => {
+    render(<BasicsStep />);
+    const nameInput = screen.getByLabelText('Connection name');
+    fireEvent.blur(nameInput);
+    expect(screen.getByText('Name is required')).toBeTruthy();
+  });
+});

--- a/apps/web/src/app/connection-wizard/BasicsStep.stories.tsx
+++ b/apps/web/src/app/connection-wizard/BasicsStep.stories.tsx
@@ -1,0 +1,12 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import BasicsStep from './BasicsStep';
+
+const meta: Meta<typeof BasicsStep> = {
+  title: 'Connection Wizard/BasicsStep',
+  component: BasicsStep,
+  parameters: { layout: 'centered' },
+};
+export default meta;
+
+type Story = StoryObj<typeof BasicsStep>;
+export const Default: Story = {};

--- a/apps/web/src/app/connection-wizard/BasicsStep.tsx
+++ b/apps/web/src/app/connection-wizard/BasicsStep.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useState } from 'react';
+
+/**
+ * Collect basic connection details.
+ */
+export default function BasicsStep() {
+  const [name, setName] = useState('');
+  const [voltage, setVoltage] = useState('');
+  const [touched, setTouched] = useState({ name: false, voltage: false });
+
+  const handleBlur = (field: 'name' | 'voltage') =>
+    setTouched((t) => ({ ...t, [field]: true }));
+
+  const nameError = touched.name && !name ? 'Name is required' : '';
+  const voltageError = touched.voltage && !voltage ? 'Voltage is required' : '';
+
+  return (
+    <form className="space-y-4">
+      <div className="nj-form-item">
+        <div className="nj-form-item__field-wrapper">
+          <input
+            id="connectionName"
+            className="nj-form-item__field"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            onBlur={() => handleBlur('name')}
+            aria-describedby="connectionNameHint"
+          />
+          <label htmlFor="connectionName" className="nj-form-item__label">
+            Connection name
+          </label>
+        </div>
+        {nameError && (
+          <span id="connectionNameHint" className="nj-form-item__errors">
+            {nameError}
+          </span>
+        )}
+      </div>
+      <div className="nj-form-item nj-form-item--select">
+        <div className="nj-form-item__field-wrapper">
+          <select
+            id="voltage"
+            className="nj-form-item__field"
+            value={voltage}
+            onChange={(e) => setVoltage(e.target.value)}
+            onBlur={() => handleBlur('voltage')}
+          >
+            <option value="" disabled hidden>
+              Select voltage
+            </option>
+            <option value="LV">LV</option>
+            <option value="HV">HV</option>
+          </select>
+          <label htmlFor="voltage" className="nj-form-item__label">
+            Voltage
+          </label>
+          <span
+            aria-hidden="true"
+            className="nj-form-item__icon material-icons"
+          >
+            keyboard_arrow_down
+          </span>
+        </div>
+        {voltageError && (
+          <span className="nj-form-item__errors">{voltageError}</span>
+        )}
+      </div>
+    </form>
+  );
+}

--- a/apps/web/src/app/connection-wizard/page.tsx
+++ b/apps/web/src/app/connection-wizard/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import WizardShell from './WizardShell';
+import BasicsStep from './BasicsStep';
 
 /**
  * Show the connection wizard entry page.
@@ -13,6 +14,7 @@ export default function ConnectionWizardPage() {
           <h1>Connection wizard ⚡️</h1>
           <p>Follow the steps to set up your new connection.</p>
         </section>,
+        <BasicsStep key="basics" />,
         <section key="confirm">
           <h1>All done 🎉</h1>
           <p>You completed the wizard.</p>

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@nx/react": "^21.2.0",
     "@playwright/test": "^1.36.0",
     "@prisma/client": "^6.10.1",
+    "@storybook/react": "^9.0.13",
     "@swc-node/register": "~1.9.1",
     "@swc/cli": "~0.6.0",
     "@swc/core": "~1.5.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4520,6 +4520,42 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/global@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "@storybook/global@npm:5.0.0"
+  checksum: 10c0/8f1b61dcdd3a89584540896e659af2ecc700bc740c16909a7be24ac19127ea213324de144a141f7caf8affaed017d064fea0618d453afbe027cf60f54b4a6d0b
+  languageName: node
+  linkType: hard
+
+"@storybook/react-dom-shim@npm:9.0.13":
+  version: 9.0.13
+  resolution: "@storybook/react-dom-shim@npm:9.0.13"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+    storybook: ^9.0.13
+  checksum: 10c0/f11722bb93e8766d2fbef57540952a0299fec3f7a3a5f5e50a2bcc326332649a9cc9a5c9dc5cd78eedd4b5eb4cc3fc07e9535b6c5e482eaf5e8bf462fd44ab5c
+  languageName: node
+  linkType: hard
+
+"@storybook/react@npm:^9.0.13":
+  version: 9.0.13
+  resolution: "@storybook/react@npm:9.0.13"
+  dependencies:
+    "@storybook/global": "npm:^5.0.0"
+    "@storybook/react-dom-shim": "npm:9.0.13"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+    storybook: ^9.0.13
+    typescript: ">= 4.9.x"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/755a1bf694938cb19dce2923c1ead9ef166879d29cdf6ab2acfabe228fd6727d3303a1303e8482958d8c5acb6e3b6c9c13a0de466dfc06f02579ad56682d369e
+  languageName: node
+  linkType: hard
+
 "@svgr/babel-plugin-add-jsx-attribute@npm:8.0.0":
   version: 8.0.0
   resolution: "@svgr/babel-plugin-add-jsx-attribute@npm:8.0.0"
@@ -8334,6 +8370,7 @@ __metadata:
     "@nx/react": "npm:^21.2.0"
     "@playwright/test": "npm:^1.36.0"
     "@prisma/client": "npm:^6.10.1"
+    "@storybook/react": "npm:^9.0.13"
     "@swc-node/register": "npm:~1.9.1"
     "@swc/cli": "npm:~0.6.0"
     "@swc/core": "npm:~1.5.7"


### PR DESCRIPTION
## Why
- start capturing essential connection info in wizard

## Notes
- run `yarn lint --fix`, `yarn format`, `yarn ts:check`, and `yarn test` before commit

Labels: release:minor

------
https://chatgpt.com/codex/tasks/task_e_685b9d58c8dc8326a496d391a35dd506

## Summary by Sourcery

Add a new BasicsStep form to the connection wizard that captures and validates connection name and voltage inputs and integrate it into the wizard sequence

New Features:
- Introduce BasicsStep component to collect connection name and voltage with required-field validation
- Insert the BasicsStep into the connection wizard page before the confirmation step

Tests:
- Add unit tests for the new BasicsStep component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new step in the connection wizard for entering basic connection details, including connection name and voltage type, with real-time validation and user-friendly error messages.
- **Tests**
	- Added tests to ensure validation errors appear correctly when required fields are left empty.
- **Documentation**
	- Added a Storybook story to showcase the new connection wizard step.
- **Chores**
	- Added Storybook as a development dependency for UI component development and testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->