### PR TITLE
feat(web): add suggestions table step

### DIFF
--- a/apps/web/src/app/connection-wizard/SuggestionsTableStep.spec.tsx
+++ b/apps/web/src/app/connection-wizard/SuggestionsTableStep.spec.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import SuggestionsTableStep from './SuggestionsTableStep';
+
+describe('SuggestionsTableStep', () => {
+  it('displays suggestion rows', () => {
+    render(<SuggestionsTableStep />);
+    expect(screen.getByText('Standard 240V connection')).toBeTruthy();
+  });
+});

--- a/apps/web/src/app/connection-wizard/SuggestionsTableStep.tsx
+++ b/apps/web/src/app/connection-wizard/SuggestionsTableStep.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useCombinationSuggest } from './useCombinationSuggest';
+
+/**
+ * Display connection suggestions in a table.
+ */
+export default function SuggestionsTableStep() {
+  const suggestions = useCombinationSuggest();
+
+  return (
+    <section>
+      <h2>Suggested combinations ✨</h2>
+      <table className="nj-table nj-table--striped">
+        <thead>
+          <tr>
+            <th>Id</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          {suggestions.map((s) => (
+            <tr key={s.id}>
+              <td>{s.id}</td>
+              <td>{s.description}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </section>
+  );
+}

--- a/apps/web/src/app/connection-wizard/page.tsx
+++ b/apps/web/src/app/connection-wizard/page.tsx
@@ -2,6 +2,7 @@
 
 import WizardShell from './WizardShell';
 import BasicsStep from './BasicsStep';
+import SuggestionsTableStep from './SuggestionsTableStep';
 
 /**
  * Show the connection wizard entry page.
@@ -15,6 +16,7 @@ export default function ConnectionWizardPage() {
           <p>Follow the steps to set up your new connection.</p>
         </section>,
         <BasicsStep key="basics" />,
+        <SuggestionsTableStep key="suggestions" />,
         <section key="confirm">
           <h1>All done 🎉</h1>
           <p>You completed the wizard.</p>

--- a/apps/web/src/app/connection-wizard/useCombinationSuggest.spec.tsx
+++ b/apps/web/src/app/connection-wizard/useCombinationSuggest.spec.tsx
@@ -1,0 +1,9 @@
+import { renderHook } from '@testing-library/react';
+import { useCombinationSuggest } from './useCombinationSuggest';
+
+describe('useCombinationSuggest', () => {
+  it('returns suggestions', () => {
+    const { result } = renderHook(() => useCombinationSuggest());
+    expect(result.current.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/app/connection-wizard/useCombinationSuggest.ts
+++ b/apps/web/src/app/connection-wizard/useCombinationSuggest.ts
@@ -1,0 +1,25 @@
+'use client';
+
+import { useState } from 'react';
+
+/**
+ * Suggested combination option.
+ */
+export interface Suggestion {
+  /** Unique identifier */
+  id: string;
+  /** Human friendly description */
+  description: string;
+}
+
+/**
+ * Provide combination suggestions for new connections.
+ * Returns a static list until the API is implemented.
+ */
+export function useCombinationSuggest(): Suggestion[] {
+  const [items] = useState<Suggestion[]>([
+    { id: 'S1', description: 'Standard 240V connection' },
+    { id: 'S2', description: 'High voltage connection' },
+  ]);
+  return items;
+}


### PR DESCRIPTION
## Why
- show combo suggestions during connection setup

## Notes
- adds `useCombinationSuggest` hook and `SuggestionsTableStep` component
- integrates step into wizard and covers with tests

------
https://chatgpt.com/codex/tasks/task_e_685bb087083083268628166caef93611