### PR TITLE
feat(web): collect detailed connection info

### DIFF
--- a/apps/web/src/app/connection-wizard/BasicsStep.spec.tsx
+++ b/apps/web/src/app/connection-wizard/BasicsStep.spec.tsx
@@ -2,10 +2,15 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import BasicsStep from './BasicsStep';
 
 describe('BasicsStep', () => {
-  it('validates fields on blur', () => {
+  it('validates fields on blur', async () => {
     render(<BasicsStep />);
-    const nameInput = screen.getByLabelText('Connection name');
-    fireEvent.blur(nameInput);
-    expect(screen.getByText('Name is required')).toBeTruthy();
+    fireEvent.blur(await screen.findByLabelText('Connection name'));
+    fireEvent.blur(await screen.findByLabelText('Voltage'));
+    fireEvent.blur(await screen.findByLabelText('MPAN'));
+    fireEvent.blur(await screen.findByLabelText('Required energisation date'));
+    fireEvent.blur(await screen.findByLabelText('Expected usage (kWh/year)'));
+    fireEvent.click(await screen.findByLabelText('Half hourly'));
+    fireEvent.click(await screen.findByLabelText('Half hourly')); // blur via click
+    expect(screen.getAllByText(/required/i)).toHaveLength(5);
   });
 });

--- a/apps/web/src/app/connection-wizard/BasicsStep.tsx
+++ b/apps/web/src/app/connection-wizard/BasicsStep.tsx
@@ -1,6 +1,24 @@
 'use client';
 
+import dynamic from 'next/dynamic';
 import { useState } from 'react';
+
+const NJFormItem = dynamic(
+  () =>
+    import('@engie-group/fluid-design-system-react').then((m) => m.NJFormItem),
+  { ssr: false }
+);
+const NJRadioGroup = dynamic(
+  () =>
+    import('@engie-group/fluid-design-system-react').then(
+      (m) => m.NJRadioGroup
+    ),
+  { ssr: false }
+);
+const NJRadio = dynamic(
+  () => import('@engie-group/fluid-design-system-react').then((m) => m.NJRadio),
+  { ssr: false }
+);
 
 /**
  * Collect basic connection details.
@@ -8,65 +26,136 @@ import { useState } from 'react';
 export default function BasicsStep() {
   const [name, setName] = useState('');
   const [voltage, setVoltage] = useState('');
-  const [touched, setTouched] = useState({ name: false, voltage: false });
+  const [mpan, setMpan] = useState('');
+  const [energisationDate, setEnergisationDate] = useState('');
+  const [customerType, setCustomerType] = useState('');
+  const [usage, setUsage] = useState('');
+  const [touched, setTouched] = useState({
+    name: false,
+    voltage: false,
+    mpan: false,
+    energisationDate: false,
+    customerType: false,
+    usage: false,
+  });
 
-  const handleBlur = (field: 'name' | 'voltage') =>
-    setTouched((t) => ({ ...t, [field]: true }));
+  const handleBlur = (
+    field:
+      | 'name'
+      | 'voltage'
+      | 'mpan'
+      | 'energisationDate'
+      | 'customerType'
+      | 'usage'
+  ) => setTouched((t) => ({ ...t, [field]: true }));
 
   const nameError = touched.name && !name ? 'Name is required' : '';
   const voltageError = touched.voltage && !voltage ? 'Voltage is required' : '';
+  const mpanError = touched.mpan && !mpan ? 'MPAN is required' : '';
+  const dateError =
+    touched.energisationDate && !energisationDate
+      ? 'Energisation date is required'
+      : '';
+  const customerError =
+    touched.customerType && !customerType
+      ? 'Select half hourly or non half hourly'
+      : '';
+  const usageError =
+    touched.usage && !usage ? 'Expected usage is required' : '';
 
   return (
     <form className="space-y-4">
-      <div className="nj-form-item">
-        <div className="nj-form-item__field-wrapper">
-          <input
-            id="connectionName"
-            className="nj-form-item__field"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            onBlur={() => handleBlur('name')}
-            aria-describedby="connectionNameHint"
-          />
-          <label htmlFor="connectionName" className="nj-form-item__label">
-            Connection name
-          </label>
-        </div>
-        {nameError && (
-          <span id="connectionNameHint" className="nj-form-item__errors">
-            {nameError}
-          </span>
-        )}
-      </div>
-      <div className="nj-form-item nj-form-item--select">
-        <div className="nj-form-item__field-wrapper">
-          <select
-            id="voltage"
-            className="nj-form-item__field"
-            value={voltage}
-            onChange={(e) => setVoltage(e.target.value)}
-            onBlur={() => handleBlur('voltage')}
-          >
-            <option value="" disabled hidden>
-              Select voltage
-            </option>
-            <option value="LV">LV</option>
-            <option value="HV">HV</option>
-          </select>
-          <label htmlFor="voltage" className="nj-form-item__label">
-            Voltage
-          </label>
-          <span
-            aria-hidden="true"
-            className="nj-form-item__icon material-icons"
-          >
-            keyboard_arrow_down
-          </span>
-        </div>
-        {voltageError && (
-          <span className="nj-form-item__errors">{voltageError}</span>
-        )}
-      </div>
+      <NJFormItem
+        id="connectionName"
+        label="Connection name"
+        value={name}
+        onChange={(e) =>
+          setName((e.target as HTMLInputElement | HTMLSelectElement).value)
+        }
+        onBlur={() => handleBlur('name')}
+        hasError={!!nameError}
+        subscriptMessage={nameError}
+      />
+      <NJFormItem
+        id="voltage"
+        label="Voltage"
+        isSelect
+        iconName="keyboard_arrow_down"
+        value={voltage}
+        onChange={(e) =>
+          setVoltage((e.target as HTMLInputElement | HTMLSelectElement).value)
+        }
+        onBlur={() => handleBlur('voltage')}
+        hasError={!!voltageError}
+        subscriptMessage={voltageError}
+      >
+        <select data-child-name="inputField">
+          <option value="" disabled hidden>
+            Select voltage
+          </option>
+          <option value="LV">LV</option>
+          <option value="HV">HV</option>
+        </select>
+      </NJFormItem>
+      <NJFormItem
+        id="mpan"
+        label="MPAN"
+        value={mpan}
+        onChange={(e) =>
+          setMpan((e.target as HTMLInputElement | HTMLSelectElement).value)
+        }
+        onBlur={() => handleBlur('mpan')}
+        hasError={!!mpanError}
+        subscriptMessage={mpanError}
+      />
+      <NJFormItem
+        id="energisationDate"
+        label="Required energisation date"
+        type="date"
+        value={energisationDate}
+        onChange={(e) =>
+          setEnergisationDate(
+            (e.target as HTMLInputElement | HTMLSelectElement).value
+          )
+        }
+        onBlur={() => handleBlur('energisationDate')}
+        hasError={!!dateError}
+        subscriptMessage={dateError}
+      />
+      <NJFormItem
+        id="usage"
+        label="Expected usage (kWh/year)"
+        type="number"
+        value={usage}
+        onChange={(e) =>
+          setUsage((e.target as HTMLInputElement | HTMLSelectElement).value)
+        }
+        onBlur={() => handleBlur('usage')}
+        hasError={!!usageError}
+        subscriptMessage={usageError}
+      />
+      <NJRadioGroup
+        legend="Half hourly customer?"
+        onChange={(id) => {
+          setCustomerType(id);
+          handleBlur('customerType');
+        }}
+        checkedId={customerType}
+        hasError={!!customerError}
+      >
+        <NJRadio label="Half hourly" value="HH" id="hh" name="customerType" />
+        <NJRadio
+          label="Non half hourly"
+          value="NHH"
+          id="nhh"
+          name="customerType"
+        />
+      </NJRadioGroup>
+      {customerError && (
+        <p className="nj-form-item__subscript" id="customerType-subscript">
+          {customerError}
+        </p>
+      )}
     </form>
   );
 }


### PR DESCRIPTION
## Why
Enhances the connection wizard with essential details for new connections.

## Summary
- extend basic step with MPAN, energisation date, customer type and usage
- test additional validation logic

## Testing
- `yarn lint --fix`
- `yarn format`
- `yarn ts:check`
- `yarn nx run-many --target=test`
- `yarn e2e`


------
https://chatgpt.com/codex/tasks/task_e_685d2e29319483269ca177ff3e71814b

## Summary by Sourcery

Implement additional connection detail fields in the BasicsStep form and update validation tests to cover the new inputs

New Features:
- Add MPAN, energisation date, expected usage, and customer type fields to the connection wizard basics step

Enhancements:
- Refactor form rendering to use dynamic NJFormItem and NJRadioGroup components for inputs and selection

Tests:
- Extend unit tests to validate the new fields and their error messages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the form to collect additional connection details, including MPAN, energisation date, customer type, and expected usage.
  * Introduced enhanced validation with error messages for all required fields.
  * Updated the form interface to use design system components for a more consistent user experience.

* **Tests**
  * Improved test coverage to validate all required fields and their error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->