### PR TITLE
feat(web): preload fonts

### DIFF
--- a/apps/web/specs/layout.spec.tsx
+++ b/apps/web/specs/layout.spec.tsx
@@ -1,9 +1,15 @@
 import React from 'react';
 import { render } from '@testing-library/react';
+
+jest.mock('next/head', () => ({
+  __esModule: true,
+  default: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
 import RootLayout from '../src/app/layout';
 
 describe('RootLayout', () => {
   it('renders children', () => {
+    document.documentElement.innerHTML = '';
     const { baseElement } = render(
       <RootLayout>
         <p>Test Child</p>
@@ -14,9 +20,25 @@ describe('RootLayout', () => {
   });
 
   it('includes the navigation header', () => {
+    document.documentElement.innerHTML = '';
     const { container } = render(<RootLayout></RootLayout>, {
       container: document.documentElement,
     });
     expect(container.querySelector('header.nj-header')).toBeTruthy();
+  });
+
+  it('links Material Icons and Lato fonts', () => {
+    document.documentElement.innerHTML = '';
+    const { container } = render(<RootLayout />, {
+      container: document.documentElement,
+    });
+    const links = Array.from(container.querySelectorAll('link'));
+    const hrefs = links.map((link) => link.getAttribute('href'));
+    expect(hrefs).toContain(
+      'https://fonts.googleapis.com/icon?family=Material+Icons'
+    );
+    expect(hrefs).toContain(
+      'https://fonts.googleapis.com/css2?family=Lato:wght@300;400;700&display=swap'
+    );
   });
 });

--- a/apps/web/specs/layout.spec.tsx
+++ b/apps/web/specs/layout.spec.tsx
@@ -9,7 +9,7 @@ jest.mock('next/font/google', () => ({
   Lato: jest.fn(() => ({ className: 'lato' })),
 }));
 
-import { lato } from '../src/app/layout';
+import { lato } from '../src/app/fonts';
 import RootLayout from '../src/app/layout';
 
 describe('RootLayout', () => {

--- a/apps/web/specs/layout.spec.tsx
+++ b/apps/web/specs/layout.spec.tsx
@@ -5,6 +5,11 @@ jest.mock('next/head', () => ({
   __esModule: true,
   default: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
 }));
+jest.mock('next/font/google', () => ({
+  Lato: jest.fn(() => ({ className: 'lato' })),
+}));
+
+import { lato } from '../src/app/layout';
 import RootLayout from '../src/app/layout';
 
 describe('RootLayout', () => {
@@ -27,7 +32,7 @@ describe('RootLayout', () => {
     expect(container.querySelector('header.nj-header')).toBeTruthy();
   });
 
-  it('links Material Icons and Lato fonts', () => {
+  it('applies Lato class and links Material Icons', () => {
     document.documentElement.innerHTML = '';
     const { container } = render(<RootLayout />, {
       container: document.documentElement,
@@ -37,8 +42,6 @@ describe('RootLayout', () => {
     expect(hrefs).toContain(
       'https://fonts.googleapis.com/icon?family=Material+Icons'
     );
-    expect(hrefs).toContain(
-      'https://fonts.googleapis.com/css2?family=Lato:wght@300;400;700&display=swap'
-    );
+    expect(document.querySelector('html')?.className).toContain(lato.className);
   });
 });

--- a/apps/web/src/app/fonts.ts
+++ b/apps/web/src/app/fonts.ts
@@ -1,0 +1,8 @@
+import { Lato } from 'next/font/google';
+
+export const lato = Lato({
+  weight: ['300', '400', '700'],
+  display: 'swap',
+  subsets: ['latin'],
+  preload: true,
+});

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,6 +1,7 @@
-import './global.css';
+import Head from 'next/head';
 import FluidProvider from './components/FluidProvider';
 import Header from './components/Header';
+import './global.css';
 
 /**
  * Document-wide metadata.
@@ -19,6 +20,16 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
+      <Head>
+        <link
+          href="https://fonts.googleapis.com/icon?family=Material+Icons"
+          rel="stylesheet"
+        />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Lato:wght@300;400;700&display=swap"
+          rel="stylesheet"
+        />
+      </Head>
       <body>
         <FluidProvider>
           <Header />

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,7 +1,15 @@
 import Head from 'next/head';
+import { Lato } from 'next/font/google';
 import FluidProvider from './components/FluidProvider';
 import Header from './components/Header';
 import './global.css';
+
+export const lato = Lato({
+  weight: ['300', '400', '700'],
+  display: 'swap',
+  subsets: ['latin'],
+  preload: true,
+});
 
 /**
  * Document-wide metadata.
@@ -19,14 +27,10 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en">
+    <html lang="en" className={lato.className}>
       <Head>
         <link
           href="https://fonts.googleapis.com/icon?family=Material+Icons"
-          rel="stylesheet"
-        />
-        <link
-          href="https://fonts.googleapis.com/css2?family=Lato:wght@300;400;700&display=swap"
           rel="stylesheet"
         />
       </Head>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,15 +1,8 @@
 import Head from 'next/head';
-import { Lato } from 'next/font/google';
 import FluidProvider from './components/FluidProvider';
 import Header from './components/Header';
+import { lato } from './fonts';
 import './global.css';
-
-export const lato = Lato({
-  weight: ['300', '400', '700'],
-  display: 'swap',
-  subsets: ['latin'],
-  preload: true,
-});
 
 /**
  * Document-wide metadata.


### PR DESCRIPTION
## Why
Ensure icon and text fonts load before Fluid Design styles.

## Changes
- inject Material Icons and Lato in root layout
- test font links rendering


------
https://chatgpt.com/codex/tasks/task_e_685d5047ef148326b80d12a005fcba38

## Summary by Sourcery

Preload key icon and text fonts by injecting Google Fonts links into the root layout and add tests to confirm their inclusion.

Enhancements:
- Preload Material Icons and Lato fonts in the root layout to ensure they load before Fluid Design styles.

Tests:
- Add a test to verify that the Material Icons and Lato font links are rendered in the layout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Material Icons and Lato font styles by including their stylesheets in the application layout.

* **Tests**
  * Improved layout tests to verify the presence of Material Icons and Lato font stylesheets.
  * Enhanced test reliability by ensuring a clean DOM state before each test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->