### PR TITLE
docs(web): clarify FluidProvider auto-init

### DIFF
--- a/apps/web/src/app/components/FluidProvider.tsx
+++ b/apps/web/src/app/components/FluidProvider.tsx
@@ -4,10 +4,13 @@ import { useEffect, type PropsWithChildren } from 'react';
 
 /**
  * Enables the Engie Fluid Design System in the browser.
+ * Loads the auto-init script once after the component mounts.
  */
 export default function FluidProvider({ children }: PropsWithChildren) {
+  // Auto-init attaches behaviour to DOM nodes outside test runs.
   useEffect(() => {
     if (typeof window !== 'undefined' && process.env.NODE_ENV !== 'test') {
+      // This dynamic import runs after the first render to keep the bundle lean.
       void import('@engie-group/fluid-design-system/lib/auto-init.js');
     }
   }, []);


### PR DESCRIPTION
## Summary
- document FluidProvider's auto-init behaviour

## Why
- make it clear when dynamic import runs

## Testing
- `yarn lint --fix`
- `yarn format`
- `yarn ts:check`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_685d5e2b8cb0832697db1abae227a3e9