### PR TITLE
fix(web): prevent hydration error when loading Material Icons

### DIFF
--- a/apps/web/specs/layout.spec.tsx
+++ b/apps/web/specs/layout.spec.tsx
@@ -5,7 +5,8 @@ jest.mock('next/font/google', () => ({
 }));
 
 import { lato } from '../src/app/fonts';
-import RootLayout, { metadata } from '../src/app/layout';
+import RootLayout from '../src/app/layout';
+import Head from '../src/app/head';
 
 describe('RootLayout', () => {
   it('renders children', () => {
@@ -31,9 +32,9 @@ describe('RootLayout', () => {
     document.documentElement.innerHTML = '';
     render(<RootLayout />, { container: document.documentElement });
     expect(document.querySelector('html')?.className).toContain(lato.className);
-    const links = metadata.icons?.other ?? [];
-    const hrefs = Array.isArray(links) ? links.map((l) => l.url) : [links.url];
-    expect(hrefs).toContain(
+    const { container } = render(<Head />);
+    const link = container.querySelector('link[rel="stylesheet"]');
+    expect(link?.getAttribute('href')).toBe(
       'https://fonts.googleapis.com/icon?family=Material+Icons'
     );
   });

--- a/apps/web/src/app/head.tsx
+++ b/apps/web/src/app/head.tsx
@@ -1,0 +1,10 @@
+export default function Head() {
+  return (
+    <>
+      <link
+        rel="stylesheet"
+        href="https://fonts.googleapis.com/icon?family=Material+Icons"
+      />
+    </>
+  );
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -9,14 +9,6 @@ import './global.css';
  */
 export const metadata: Metadata = {
   title: 'Welcome to electric MDD UK',
-  icons: {
-    other: [
-      {
-        url: 'https://fonts.googleapis.com/icon?family=Material+Icons',
-        rel: 'stylesheet',
-      },
-    ],
-  },
 };
 
 /**


### PR DESCRIPTION
## Why

Material Icons were injected via `metadata.icons` which broke server-client rendering and caused a hydration error.

## What

- remove Material Icons from `metadata`
- add dedicated `head.tsx` to include the icon stylesheet
- adjust layout tests

## Testing

- `yarn lint --fix`
- `yarn nx run prisma:lint`
- `yarn format`
- `yarn ts:check`
- `yarn nx run-many --target=test`
- `yarn e2e`

------
https://chatgpt.com/codex/tasks/task_e_685e5e04fb108326ae6950b5cbd72c83