### PR TITLE
feat(web): test head component

### DIFF
--- a/apps/web/src/app/head.spec.tsx
+++ b/apps/web/src/app/head.spec.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import Head from './head';
+
+describe('Head', () => {
+  it('links to Material Icons stylesheet', () => {
+    const { container } = render(<Head />);
+    const link = container.querySelector('link[rel="stylesheet"]');
+    expect(link?.getAttribute('href')).toBe(
+      'https://fonts.googleapis.com/icon?family=Material+Icons'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test for `Head` component verifying Material Icons link

## Why
- ensure `<Head>` includes Material Icons stylesheet

## Testing
- `yarn lint --fix`
- `yarn nx run prisma:lint`
- `yarn format`
- `yarn ts:check`
- `yarn nx run-many --target=test --output-style=static`


------
https://chatgpt.com/codex/tasks/task_e_685e94d522648326be517e2488fe20ca

## Summary by Sourcery

Tests:
- Introduce head.spec.tsx to verify Material Icons link in the <Head> component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a new test to verify that the Material Icons stylesheet is correctly included in the Head component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->